### PR TITLE
Fix #52 - handling of long name/emails

### DIFF
--- a/src/app/components/ContactSummary.js
+++ b/src/app/components/ContactSummary.js
@@ -22,7 +22,7 @@ const ContactSummary = ({ properties }) => {
         email && {
             icon: 'email',
             component: (
-                <a href={`mailto:${email}`} title={`${email}`}>
+                <a href={`mailto:${email}`} title={email}>
                     {email}
                 </a>
             )

--- a/src/app/components/ContactSummary.js
+++ b/src/app/components/ContactSummary.js
@@ -19,7 +19,14 @@ const ContactSummary = ({ properties }) => {
     const org = getFirstValue(properties, 'org');
 
     const summary = [
-        email && { icon: 'email', component: <a href={`mailto:${email}`}>{email}</a> },
+        email && {
+            icon: 'email',
+            component: (
+                <a href={`mailto:${email}`} title={`${email}`}>
+                    {email}
+                </a>
+            )
+        },
         tel && { icon: 'phone', component: <a href={`tel:${tel}`}>{tel}</a> },
         adr && { icon: 'address', component: formatAdr(adr) },
         org && { icon: 'organization', component: org }
@@ -39,13 +46,13 @@ const ContactSummary = ({ properties }) => {
                 )}
             </div>
             <div className="pl1">
-                <h2 className="mb0-5">{name}</h2>
+                <h2 className="mb0-5 ellipsis">{name}</h2>
                 <ul className="unstyled m0">
                     {summary.map(({ icon, component }) => {
                         return (
-                            <li key={icon} className="flex flex-items-center mb0-5">
+                            <li key={icon} className="flex flex-nowrap flex-items-center mb0-5">
                                 <Icon name={icon} className="mr0-5" />
-                                {component}
+                                <span className="ellipsis">{component}</span>
                             </li>
                         );
                     })}

--- a/src/app/components/ContactViewProperty.js
+++ b/src/app/components/ContactViewProperty.js
@@ -23,7 +23,7 @@ const ContactViewProperty = ({ property, properties, contactID }) => {
             case 'email': {
                 return (
                     <>
-                        <a className="mr0-5" href={`mailto:${value}`} title={`${value}`}>
+                        <a className="mr0-5" href={`mailto:${value}`} title={value}>
                             {value}
                         </a>
                         {property.contactGroups.length

--- a/src/app/components/ContactViewProperty.js
+++ b/src/app/components/ContactViewProperty.js
@@ -23,7 +23,7 @@ const ContactViewProperty = ({ property, properties, contactID }) => {
             case 'email': {
                 return (
                     <>
-                        <a className="mr0-5" href={`mailto:${value}`}>
+                        <a className="mr0-5" href={`mailto:${value}`} title={`${value}`}>
                             {value}
                         </a>
                         {property.contactGroups.length
@@ -97,8 +97,8 @@ const ContactViewProperty = ({ property, properties, contactID }) => {
         <Row>
             <ContactLabelProperty field={field} type={type} first={first} />
             <div className="flex flex-nowrap flex-items-center w100">
-                <span className="mr0-5">{getContent()}</span>
-                {getActions()}
+                <span className="mr0-5 ellipsis">{getContent()}</span>
+                <span className="flex-item-noshrink">{getActions()}</span>
             </div>
         </Row>
     );


### PR DESCRIPTION
## Short description of what this resolves:

- Incorrect handling of long name/emails
- bad display of button group (icon missing, etc.)

## Changes proposed in this pull request:

- wrapped buttons in a `flex-item-noshrink` to avoid it being shrinked (this part should not be flexible)
- added `ellipsis` class on elements to activate `text-overflow: ellipsis` when needed (added `title` attribute on mailto, best practice we always do when ellipsis is used)

Bonus : also fixed icon email display when long name, to avoid name being put under this icon

Fixes #52


![image](https://user-images.githubusercontent.com/2578321/62371753-e74d2e80-b535-11e9-8c32-746579a98e4b.png)

🎉 (this is my first PR on React project, I really prefer this to Angular 👍  )
