### PR TITLE
Fix #57 - contact group name cut off

### DIFF
--- a/src/app/components/ContactPlaceholder.js
+++ b/src/app/components/ContactPlaceholder.js
@@ -145,7 +145,7 @@ const ContactPlaceholder = ({ contacts, contactGroupID, user, onUncheck }) => {
         return (
             <div className="p2 view-column-detail flex-item-fluid">
                 <div className="aligncenter">
-                    <h1 className="ellipsis">{Name}</h1>
+                    <h1 className="ellipsis lh-standard">{Name}</h1>
                     <div className="mb1">
                         {c('Info').ngettext(
                             msgid`You have ${countContacts} contact in your address book`,


### PR DESCRIPTION
## Short description of what this resolves:

Some contact groups have the bottom part of their letters cut-off in the view of the right-part of the screen.
This was caused by vertical rythm formulas of the Design System (of course, with user-generated content... ¯\_(ツ)_/¯ ).

## Changes proposed in this pull request:

- created a helper `lh-standard` in design system to apply standard `line-height` https://github.com/ProtonMail/design-system/commit/0b197d44f9c7c1ca64987e53aba8dad797e92c1d
- applied this helper to contact group name (will also fix emojis issues 🎉 )

Fixes #57 

Before:
![image](https://user-images.githubusercontent.com/2578321/62375876-98a49200-b53f-11e9-904d-7161c8840f28.png)

After:
![image](https://user-images.githubusercontent.com/2578321/62375583-eec50580-b53e-11e9-95ac-a4ec22cbdb86.png)



