### PR TITLE
Fix tooltips scrolling

### DIFF
--- a/src/app/components/ContactModalProperties.js
+++ b/src/app/components/ContactModalProperties.js
@@ -58,7 +58,7 @@ const ContactModalProperties = ({ properties: allProperties, field, onChange, on
             <h3 className="mb1 flex flex-nowrap flex-items-center">
                 <Icon className="mr0-5" name={iconName} />
                 <span className="mr0-5">{title}</span>
-                {['fn', 'email'].includes(field) ? null : <EncryptedIcon />}
+                {['fn', 'email'].includes(field) ? null : <EncryptedIcon scrollContainerClass="pm-modalContentInner" />}
             </h3>
             {onOrderChange ? (
                 <OrderableContainer helperClass="row--orderable" onSortEnd={handleSortEnd} useDragHandle>

--- a/src/app/components/ContactsList.js
+++ b/src/app/components/ContactsList.js
@@ -86,7 +86,14 @@ const ContactsList = ({ contacts, onCheck, history, contactID, location }) => {
                                 <div>
                                     {LabelIDs.map((labelID) => {
                                         const { Color, Name } = mapContactGroups[labelID];
-                                        return <ContactGroupIcon key={labelID} name={Name} color={Color} />;
+                                        return (
+                                            <ContactGroupIcon
+                                                scrollContainerClass="contacts-list"
+                                                key={labelID}
+                                                name={Name}
+                                                color={Color}
+                                            />
+                                        );
                                     })}
                                 </div>
                             ) : null}
@@ -132,6 +139,7 @@ const ContactsList = ({ contacts, onCheck, history, contactID, location }) => {
             <AutoSizer>
                 {({ height, width }) => (
                     <List
+                        className="contacts-list"
                         ref={listRef}
                         rowRenderer={Row}
                         rowCount={contacts.length + canMerge}

--- a/src/app/components/EncryptedIcon.js
+++ b/src/app/components/EncryptedIcon.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { Tooltip, Icon } from 'react-components';
 import { c } from 'ttag';
 
-const EncryptedIcon = () => {
+const EncryptedIcon = ({ ...rest }) => {
     return (
-        <Tooltip title={c('Tooltip').t`Encrypted data with verified digital signature`}>
+        <Tooltip {...rest} title={c('Tooltip').t`Encrypted data with verified digital signature`}>
             <Icon name="lock" />
         </Tooltip>
     );


### PR DESCRIPTION
By default, tooltips bind scroll events to `.main` or `body`, contact list and modals have their own classes.