### PR TITLE
Propagate props in contact group icon

### DIFF
--- a/src/app/components/ContactGroupIcon.js
+++ b/src/app/components/ContactGroupIcon.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Icon, Tooltip } from 'react-components';
 
-const ContactGroupIcon = ({ name, color }) => {
+const ContactGroupIcon = ({ name, color, ...rest }) => {
     return (
-        <Tooltip title={name}>
+        <Tooltip title={name} {...rest}>
             <Icon name="contacts-groups" color={color} />
         </Tooltip>
     );


### PR DESCRIPTION
this component got moved from react-components before my PR got merged