### PR TITLE
Fix #87 - long names display in add to groups

### DIFF
--- a/src/app/components/ContactGroupDropdown.js
+++ b/src/app/components/ContactGroupDropdown.js
@@ -177,22 +177,27 @@ const ContactGroupDropdown = ({ children, className, contactEmails, disabled }) 
                         placeholder={c('Placeholder').t`Filter groups`}
                     />
                 </div>
-                <div className="mb1">
+                <div className="mb1 pl1 pr1">
                     <ul className="unstyled m0 dropDown-contentInner">
                         {groups.map(({ ID, Name, Color }) => {
                             const checkboxId = `${uid}${ID}`;
                             return (
                                 <li
                                     key={ID}
-                                    className="flex flex-spacebetween flex-nowrap border-bottom border-bottom--dashed pt0-5 pb0-5"
+                                    className="flex flex-nowrap border-bottom border-bottom--dashed pt0-5 pb0-5"
                                 >
-                                    <label htmlFor={checkboxId} className="flex flex-nowrap">
-                                        <Icon name="contacts-groups" className="mr0-5" color={Color} />
-                                        <span className="ellipsis" title={Name}>
+                                    <label htmlFor={checkboxId} className="flex flex-nowrap flex-item-fluid">
+                                        <Icon
+                                            name="contacts-groups"
+                                            className="mr0-5 mtauto mbauto flex-item-noshrink"
+                                            color={Color}
+                                        />
+                                        <span className="ellipsis flex-item-fluid" title={Name}>
                                             {Name}
                                         </span>
                                     </label>
                                     <Checkbox
+                                        className="flex mtauto mbauto"
                                         id={checkboxId}
                                         checked={model[ID] === CHECKED}
                                         indeterminate={model[ID] === INDETERMINATE}

--- a/src/app/components/ContactGroupDropdown.js
+++ b/src/app/components/ContactGroupDropdown.js
@@ -197,7 +197,7 @@ const ContactGroupDropdown = ({ children, className, contactEmails, disabled }) 
                                         </span>
                                     </label>
                                     <Checkbox
-                                        className="flex mtauto mbauto"
+                                        className="flex flex-item-noshrink mtauto mbauto"
                                         id={checkboxId}
                                         checked={model[ID] === CHECKED}
                                         indeterminate={model[ID] === INDETERMINATE}


### PR DESCRIPTION
## Short description of what this resolves:

Long name display was broken (alignments, icon shrinking, etc.)

## Changes proposed in this pull request:

- icon and checkbox can't shrink now (`flex-item-noshrink`)
- text take the fluid (`flex-item-fluid`)
- vertical alignments (`mtauto` `mbauto` stuff)
- padding around item list

Fixes #87 

Before 
![image](https://user-images.githubusercontent.com/2578321/62695865-814e2480-b9d7-11e9-98c9-2570be866b0e.png)

After
![image](https://user-images.githubusercontent.com/2578321/62695203-1fd98600-b9d6-11e9-9091-d7b0e0b5ab60.png)
