### PR TITLE
Fix disabled property of buttons in ContactToolBar

### DIFF
--- a/src/app/components/ContactToolbar.js
+++ b/src/app/components/ContactToolbar.js
@@ -4,21 +4,23 @@ import { Icon, Checkbox } from 'react-components';
 import { c } from 'ttag';
 import ContactGroupDropdown from './ContactGroupDropdown';
 
-const ContactToolbar = ({ user, onCheck, onDelete, checked, checkedContacts, contactEmailsMap }) => {
+const ContactToolbar = ({ user, onCheck, onDelete, checked = false, contactID, checkedContacts, contactEmailsMap }) => {
+    // Include current contact as selected if none is checked
+    const activeContacts =
+        !!Object.values(checkedContacts).filter(Boolean).length || !contactID ? checkedContacts : { [contactID]: true };
+
     const handleCheck = ({ target }) => onCheck(target.checked);
 
     const contactEmailsSelected = useMemo(() => {
-        return Object.entries(checkedContacts)
+        return Object.entries(activeContacts)
             .filter(([, isChecked]) => isChecked)
-            .reduce((acc, [contactID]) => {
-                if (!contactEmailsMap[contactID]) {
+            .reduce((acc, [ID]) => {
+                if (!contactEmailsMap[ID]) {
                     return acc;
                 }
-                return acc.concat(contactEmailsMap[contactID]);
+                return acc.concat(contactEmailsMap[ID]);
             }, []);
-    }, [checkedContacts, contactEmailsMap]);
-
-    const disabled = !contactEmailsSelected.length && !location.pathname.split('/contacts/')[1];
+    }, [checkedContacts, contactEmailsMap, contactID]);
 
     return (
         <div className="toolbar flex noprint">
@@ -28,14 +30,14 @@ const ContactToolbar = ({ user, onCheck, onDelete, checked, checkedContacts, con
                 title={c('Tooltip').t`Delete`}
                 className="pl1 pr1"
                 onClick={onDelete}
-                disabled={disabled}
+                disabled={!contactEmailsSelected.length}
             >
                 <Icon name="delete" className="toolbar-icon" />
             </button>
             {user.hasPaidMail ? (
                 <ContactGroupDropdown
                     className="pl1 pr1 color-white"
-                    disabled={disabled}
+                    disabled={!contactEmailsSelected.length}
                     contactEmails={contactEmailsSelected}
                 >
                     <Icon name="contacts-groups" className="toolbar-icon" />
@@ -50,12 +52,9 @@ ContactToolbar.propTypes = {
     user: PropTypes.object,
     onCheck: PropTypes.func,
     onDelete: PropTypes.func,
+    contactID: PropTypes.string,
     checkedContacts: PropTypes.object,
     contactEmailsMap: PropTypes.object
-};
-
-ContactToolbar.defaultProps = {
-    checked: false
 };
 
 export default ContactToolbar;

--- a/src/app/components/ContactToolbar.js
+++ b/src/app/components/ContactToolbar.js
@@ -4,23 +4,17 @@ import { Icon, Checkbox } from 'react-components';
 import { c } from 'ttag';
 import ContactGroupDropdown from './ContactGroupDropdown';
 
-const ContactToolbar = ({ user, onCheck, onDelete, checked = false, contactID, checkedContacts, contactEmailsMap }) => {
-    // Include current contact as selected if none is checked
-    const activeContacts =
-        !!Object.values(checkedContacts).filter(Boolean).length || !contactID ? checkedContacts : { [contactID]: true };
-
+const ContactToolbar = ({ user, onCheck, onDelete, checked = false, activeIDs, contactEmailsMap }) => {
     const handleCheck = ({ target }) => onCheck(target.checked);
 
     const contactEmailsSelected = useMemo(() => {
-        return Object.entries(activeContacts)
-            .filter(([, isChecked]) => isChecked)
-            .reduce((acc, [ID]) => {
-                if (!contactEmailsMap[ID]) {
-                    return acc;
-                }
-                return acc.concat(contactEmailsMap[ID]);
-            }, []);
-    }, [checkedContacts, contactEmailsMap, contactID]);
+        return activeIDs.reduce((acc, ID) => {
+            if (!contactEmailsMap[ID]) {
+                return acc;
+            }
+            return acc.concat(contactEmailsMap[ID]);
+        }, []);
+    }, [activeIDs, contactEmailsMap]);
 
     return (
         <div className="toolbar flex noprint">
@@ -30,7 +24,7 @@ const ContactToolbar = ({ user, onCheck, onDelete, checked = false, contactID, c
                 title={c('Tooltip').t`Delete`}
                 className="pl1 pr1"
                 onClick={onDelete}
-                disabled={!contactEmailsSelected.length}
+                disabled={!activeIDs.length}
             >
                 <Icon name="delete" className="toolbar-icon" />
             </button>
@@ -52,8 +46,7 @@ ContactToolbar.propTypes = {
     user: PropTypes.object,
     onCheck: PropTypes.func,
     onDelete: PropTypes.func,
-    contactID: PropTypes.string,
-    checkedContacts: PropTypes.object,
+    activeIDs: PropTypes.array,
     contactEmailsMap: PropTypes.object
 };
 

--- a/src/app/components/ContactToolbar.js
+++ b/src/app/components/ContactToolbar.js
@@ -18,16 +18,24 @@ const ContactToolbar = ({ user, onCheck, onDelete, checked, checkedContacts, con
             }, []);
     }, [checkedContacts, contactEmailsMap]);
 
+    const disabled = !contactEmailsSelected.length && !location.pathname.split('/contacts/')[1];
+
     return (
         <div className="toolbar flex noprint">
             <Checkbox className="flex pl1 pr1" checked={checked} onChange={handleCheck} />
-            <button type="button" title={c('Tooltip').t`Delete`} className="pl1 pr1" onClick={onDelete}>
+            <button
+                type="button"
+                title={c('Tooltip').t`Delete`}
+                className="pl1 pr1"
+                onClick={onDelete}
+                disabled={disabled}
+            >
                 <Icon name="delete" className="toolbar-icon" />
             </button>
             {user.hasPaidMail ? (
                 <ContactGroupDropdown
                     className="pl1 pr1 color-white"
-                    disabled={!contactEmailsSelected.length}
+                    disabled={disabled}
                     contactEmails={contactEmailsSelected}
                 >
                     <Icon name="contacts-groups" className="toolbar-icon" />

--- a/src/app/containers/ContactsContainer.js
+++ b/src/app/containers/ContactsContainer.js
@@ -93,11 +93,7 @@ const ContactsContainer = ({ location, history }) => {
         });
     }, [filteredContacts, checkedContacts, contactEmailsMap]);
 
-    if (loadingContactEmails || loadingContacts || loadingUserKeys || loadingContactGroups) {
-        return <Loader />;
-    }
-
-    const getCheckedContactIDs = () => {
+    const checkedContactIDs = useMemo(() => {
         return Object.entries(checkedContacts).reduce((acc, [contactID, isChecked]) => {
             if (!isChecked) {
                 return acc;
@@ -105,16 +101,15 @@ const ContactsContainer = ({ location, history }) => {
             acc.push(contactID);
             return acc;
         }, []);
-    };
+    }, [checkedContacts]);
 
     const getCurrentContactID = () => {
         const [, contactID] = location.pathname.split('/contacts/');
         return contactID;
     };
 
-    const getActiveIDs = () => {
-        const checkedContactIDs = getCheckedContactIDs();
-        if (checkedContactIDs.length) {
+    const activeIDs = useMemo(() => {
+        if (checkedContactIDs && checkedContactIDs.length) {
             return checkedContactIDs;
         }
         const currentContactID = getCurrentContactID();
@@ -122,10 +117,14 @@ const ContactsContainer = ({ location, history }) => {
             return [currentContactID];
         }
         return [];
-    };
+    }, [checkedContactIDs, location.pathname]);
+
+    if (loadingContactEmails || loadingContacts || loadingUserKeys || loadingContactGroups) {
+        return <Loader />;
+    }
 
     const handleDelete = async () => {
-        const contactIDs = getActiveIDs();
+        const contactIDs = activeIDs();
 
         if (!Array.isArray(contactIDs) && !contactIDs.length) {
             return;
@@ -181,7 +180,7 @@ const ContactsContainer = ({ location, history }) => {
                         <ContactToolbar
                             user={user}
                             contactEmailsMap={contactEmailsMap}
-                            activeIDs={getActiveIDs()}
+                            activeIDs={activeIDs}
                             checked={checkAll}
                             onCheck={handleCheckAll}
                             onDelete={handleDelete}

--- a/src/app/containers/ContactsContainer.js
+++ b/src/app/containers/ContactsContainer.js
@@ -180,6 +180,7 @@ const ContactsContainer = ({ location, history }) => {
                         <ContactToolbar
                             user={user}
                             contactEmailsMap={contactEmailsMap}
+                            contactID={getCurrentContactID()}
                             checkedContacts={checkedContacts}
                             checked={checkAll}
                             onCheck={handleCheckAll}

--- a/src/app/containers/ContactsContainer.js
+++ b/src/app/containers/ContactsContainer.js
@@ -112,7 +112,7 @@ const ContactsContainer = ({ location, history }) => {
         return contactID;
     };
 
-    const getContactIDsToDelete = () => {
+    const getActiveIDs = () => {
         const checkedContactIDs = getCheckedContactIDs();
         if (checkedContactIDs.length) {
             return checkedContactIDs;
@@ -121,10 +121,11 @@ const ContactsContainer = ({ location, history }) => {
         if (currentContactID) {
             return [currentContactID];
         }
+        return [];
     };
 
     const handleDelete = async () => {
-        const contactIDs = getContactIDsToDelete();
+        const contactIDs = getActiveIDs();
 
         if (!Array.isArray(contactIDs) && !contactIDs.length) {
             return;
@@ -180,8 +181,7 @@ const ContactsContainer = ({ location, history }) => {
                         <ContactToolbar
                             user={user}
                             contactEmailsMap={contactEmailsMap}
-                            contactID={getCurrentContactID()}
-                            checkedContacts={checkedContacts}
+                            activeIDs={getActiveIDs()}
                             checked={checkAll}
                             onCheck={handleCheckAll}
                             onDelete={handleDelete}

--- a/src/app/containers/ContactsContainer.js
+++ b/src/app/containers/ContactsContainer.js
@@ -124,12 +124,6 @@ const ContactsContainer = ({ location, history }) => {
     }
 
     const handleDelete = async () => {
-        const contactIDs = activeIDs();
-
-        if (!Array.isArray(contactIDs) && !contactIDs.length) {
-            return;
-        }
-
         await new Promise((resolve, reject) => {
             createModal(
                 <ConfirmModal title={c('Title').t`Delete`} onConfirm={resolve} onClose={reject}>


### PR DESCRIPTION
- The contact-groups dropdown was not clickable when a contact was selected but not checked.
- It was possible to click the 'delete' button when no contact was selected or checked, prompting some React errors.

Both things are fixed now.

Closes #108 