### PR TITLE
Fix React warnings from contact-group dropdown

### DIFF
--- a/src/app/components/ContactGroupDropdown.js
+++ b/src/app/components/ContactGroupDropdown.js
@@ -150,7 +150,6 @@ const ContactGroupDropdown = ({ children, className, contactEmails, disabled }) 
                 buttonRef={anchorRef}
                 isOpen={isOpen}
                 onClick={toggle}
-                hasCaret
             >
                 {children}
             </ContactGroupDropdownButton>

--- a/src/app/components/ContactGroupDropdownButton.js
+++ b/src/app/components/ContactGroupDropdownButton.js
@@ -12,7 +12,7 @@ const ContactGroupDropdownButton = ({ buttonRef, children, isOpen, ...rest }) =>
 };
 
 ContactGroupDropdownButton.propTypes = {
-    buttonRef: PropTypes.node,
+    buttonRef: PropTypes.object,
     children: PropTypes.node,
     isOpen: PropTypes.bool
 };


### PR DESCRIPTION
- Refs are objects: `ref = { current: React.Node }`
- `ContactGroupDropdownButton` does not need to be passed `hasCaret` since it uses `DropdownCaret` by definition.

Fixes #111