### PR TITLE
Fix crash of contact group modal

### DIFF
--- a/src/app/components/ContactGroupModal.js
+++ b/src/app/components/ContactGroupModal.js
@@ -147,10 +147,10 @@ const ContactGroupModal = ({ contactGroupID, ...rest }) => {
     }, [model.contactEmails.length]);
 
     useEffect(() => {
-        if (!contactGroupID) {
+        if (!contactGroupID && !!inputNameRef.current) {
             inputNameRef.current.focus();
         }
-    }, []);
+    }, [inputNameRef]);
 
     return (
         <FormModal onSubmit={handleSubmit} loading={loading} submit={c('Action').t`Save`} title={title} {...rest}>


### PR DESCRIPTION
The crash was happening because the app was trying to access a property of a ref before populating it.

Fixes #113