### PR TITLE
Fix top navigation display

### DIFF
--- a/src/app/content/PrivateHeader.js
+++ b/src/app/content/PrivateHeader.js
@@ -34,7 +34,7 @@ const PrivateHeader = ({ search, onSearch, location }) => {
                             aria-current={!inSettings}
                         >
                             <Icon name="contacts" className="topnav-icon mr0-5 flex-item-centered-vert fill-white" />
-                            {c('Title').t`Contacts`}
+                            <span className="navigation-title topnav-linkText">{c('Title').t`Contacts`}</span>
                         </Link>
                     </li>
                     <li className="mr1">
@@ -47,7 +47,7 @@ const PrivateHeader = ({ search, onSearch, location }) => {
                                 name="settings-master"
                                 className="topnav-icon mr0-5 flex-item-centered-vert fill-white"
                             />
-                            {c('Title').t`Settings`}
+                            <span className="navigation-title topnav-linkText">{c('Title').t`Settings`}</span>
                         </Link>
                     </li>
                     {isFree ? (


### PR DESCRIPTION
Same as for https://github.com/ProtonMail/protonmail-settings/pull/117 

Some classes were missing, I need them in order to style all projects the same way:

![image](https://user-images.githubusercontent.com/2578321/63699317-d89a2480-c820-11e9-8629-176fa0de3bb2.png)
