### PR TITLE
Fix #128 - import contact icon (and other fixes)

### DIFF
--- a/src/app/components/import/AttachedFile.js
+++ b/src/app/components/import/AttachedFile.js
@@ -25,7 +25,9 @@ const AttachedFile = ({ file, iconName, className, clear, onClear, ...rest }) =>
             </div>
             <div className="message-attachmentInfo p0-5 flex flex-nowrap w90">
                 <div className="flex-item-fluid pr1">
-                    <div className="ellipsis">{fileName}</div>
+                    <div className="ellipsis" title={fileName}>
+                        {fileName}
+                    </div>
                     <div>{`${extension.toUpperCase()} - ${humanSize(file.size)}`}</div>
                 </div>
                 <Button className="flex-item-noshrink" onClick={onClear}>

--- a/src/app/components/import/AttachedFile.js
+++ b/src/app/components/import/AttachedFile.js
@@ -19,16 +19,18 @@ const AttachedFile = ({ file, iconName, className, clear, onClear, ...rest }) =>
     const [fileName, extension] = splitExtension(file.name);
 
     return (
-        <div className={`flex w100 ${className}`} {...rest}>
-            <div className="bordered-container p0-5 mb1 flex flex-spacebetween w10">
-                <Icon name={iconName} />
+        <div className={`flex bordered-container w100 ${className}`} {...rest}>
+            <div className=" p0-5 flex flex-item-noshrink w10">
+                <Icon name={iconName} className="mauto" />
             </div>
-            <div className="bordered-container p0-5 mb1 flex flex-spacebetween w90">
-                <div>
-                    <div>{fileName}</div>
+            <div className="message-attachmentInfo p0-5 flex flex-nowrap w90">
+                <div className="flex-item-fluid pr1">
+                    <div className="ellipsis">{fileName}</div>
                     <div>{`${extension.toUpperCase()} - ${humanSize(file.size)}`}</div>
                 </div>
-                <Button onClick={onClear}>{clear}</Button>
+                <Button className="flex-item-noshrink" onClick={onClear}>
+                    {clear}
+                </Button>
             </div>
         </div>
     );


### PR DESCRIPTION
Icon alignment in the import contacts modal is not properly set.

- fixed icon alignment
- removed double borders
- added `flex-item-noshrink` to elements that should not be flexible
- also fix display in case of an import with looooooooooooong filename (`ellipsis`, etc.).

Once fix applied:
![image](https://user-images.githubusercontent.com/2578321/64112790-b6585780-cd88-11e9-8827-302383a63135.png)
