### PR TITLE
Improvements for contact group dropdown

### DIFF
--- a/src/app/components/Contact.js
+++ b/src/app/components/Contact.js
@@ -7,7 +7,7 @@ import useContact from '../hooks/useContact';
 import { prepareContact } from '../helpers/decrypt';
 import ContactView from './ContactView';
 
-const Contact = ({ contactID, userKeysList }) => {
+const Contact = ({ contactID, contactEmails, userKeysList }) => {
     const [model, setModel] = useState({ ID: contactID });
     const ref = useRef(contactID);
     const [contact, contactLoading, contactFetchError] = useContact(contactID);
@@ -36,11 +36,12 @@ const Contact = ({ contactID, userKeysList }) => {
         return <Loader />;
     }
 
-    return <ContactView properties={properties} contactID={contactID} errors={errors} />;
+    return <ContactView properties={properties} contactID={contactID} contactEmails={contactEmails} errors={errors} />;
 };
 
 Contact.propTypes = {
     contactID: PropTypes.string.isRequired,
+    contactEmails: PropTypes.arrayOf(PropTypes.object).isRequired,
     userKeysList: PropTypes.array
 };
 

--- a/src/app/components/Contact.js
+++ b/src/app/components/Contact.js
@@ -7,7 +7,7 @@ import useContact from '../hooks/useContact';
 import { prepareContact } from '../helpers/decrypt';
 import ContactView from './ContactView';
 
-const Contact = ({ contactID, contactEmails, userKeysList }) => {
+const Contact = ({ contactID, contactEmails, contactGroupsMap, userKeysList }) => {
     const [model, setModel] = useState({ ID: contactID });
     const ref = useRef(contactID);
     const [contact, contactLoading, contactFetchError] = useContact(contactID);
@@ -36,12 +36,21 @@ const Contact = ({ contactID, contactEmails, userKeysList }) => {
         return <Loader />;
     }
 
-    return <ContactView properties={properties} contactID={contactID} contactEmails={contactEmails} errors={errors} />;
+    return (
+        <ContactView
+            properties={properties}
+            contactID={contactID}
+            contactEmails={contactEmails}
+            contactGroupsMap={contactGroupsMap}
+            errors={errors}
+        />
+    );
 };
 
 Contact.propTypes = {
     contactID: PropTypes.string.isRequired,
     contactEmails: PropTypes.arrayOf(PropTypes.object).isRequired,
+    contactGroupsMap: PropTypes.object.isRequired,
     userKeysList: PropTypes.array
 };
 

--- a/src/app/components/ContactView.js
+++ b/src/app/components/ContactView.js
@@ -10,7 +10,7 @@ import { toICAL } from '../helpers/vcard';
 import ContactSummary from './ContactSummary';
 import ContactViewProperties from './ContactViewProperties';
 
-const ContactView = ({ properties = [], contactID, contactEmails, errors }) => {
+const ContactView = ({ properties = [], contactID, contactEmails, contactGroupsMap, errors }) => {
     const { createModal } = useModals();
 
     const openContactModal = () => {
@@ -44,6 +44,7 @@ const ContactView = ({ properties = [], contactID, contactEmails, errors }) => {
                 <ContactViewProperties
                     contactID={contactID}
                     contactEmails={contactEmails}
+                    contactGroupsMap={contactGroupsMap}
                     properties={properties}
                     field="email"
                 />
@@ -65,6 +66,7 @@ const ContactPropertyPropTypes = PropTypes.shape({
 ContactView.propTypes = {
     contactID: PropTypes.string.isRequired,
     contactEmails: PropTypes.arrayOf(PropTypes.object).isRequired,
+    contactGroupsMap: PropTypes.object.isRequired,
     properties: PropTypes.arrayOf(ContactPropertyPropTypes),
     errors: PropTypes.array
 };

--- a/src/app/components/ContactView.js
+++ b/src/app/components/ContactView.js
@@ -10,7 +10,7 @@ import { toICAL } from '../helpers/vcard';
 import ContactSummary from './ContactSummary';
 import ContactViewProperties from './ContactViewProperties';
 
-const ContactView = ({ properties, contactID, errors }) => {
+const ContactView = ({ properties = [], contactID, contactEmails, errors }) => {
     const { createModal } = useModals();
 
     const openContactModal = () => {
@@ -41,7 +41,12 @@ const ContactView = ({ properties, contactID, errors }) => {
             <ContactViewErrors errors={errors} />
             <ContactSummary properties={properties} />
             <div className="pl1 pr1">
-                <ContactViewProperties contactID={contactID} properties={properties} field="email" />
+                <ContactViewProperties
+                    contactID={contactID}
+                    contactEmails={contactEmails}
+                    properties={properties}
+                    field="email"
+                />
                 <ContactViewProperties contactID={contactID} properties={properties} field="tel" />
                 <ContactViewProperties contactID={contactID} properties={properties} field="adr" />
                 <ContactViewProperties contactID={contactID} properties={properties} />
@@ -58,13 +63,10 @@ const ContactPropertyPropTypes = PropTypes.shape({
 });
 
 ContactView.propTypes = {
-    contactID: PropTypes.string,
+    contactID: PropTypes.string.isRequired,
+    contactEmails: PropTypes.arrayOf(PropTypes.object).isRequired,
     properties: PropTypes.arrayOf(ContactPropertyPropTypes),
     errors: PropTypes.array
-};
-
-ContactView.defaultProps = {
-    properties: []
 };
 
 export default ContactView;

--- a/src/app/components/ContactViewProperties.js
+++ b/src/app/components/ContactViewProperties.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { c } from 'ttag';
-import { Icon, useContactEmails } from 'react-components';
+import { Icon } from 'react-components';
 
 import ContactViewProperty from './ContactViewProperty';
 import { OTHER_INFORMATION_FIELDS } from '../constants';
@@ -14,7 +14,7 @@ const ICONS = {
     other: 'info'
 };
 
-const ContactViewProperties = ({ properties: allProperties, contactID, field }) => {
+const ContactViewProperties = ({ properties: allProperties, contactID, contactEmails, field }) => {
     const TITLES = {
         email: c('Title').t`Email addresses`,
         tel: c('Title').t`Phone numbers`,
@@ -26,21 +26,7 @@ const ContactViewProperties = ({ properties: allProperties, contactID, field }) 
     const toExclude = ['photo', 'org', 'logo'];
     const fields = field ? [field] : OTHER_INFORMATION_FIELDS.filter((field) => !toExclude.includes(field));
 
-    const [contactEmails] = useContactEmails();
-    const filteredContactEmails = contactEmails.filter(({ ContactID }) => ContactID === contactID);
-    /*
-        Each email has an emailD. This ID is present in `contactEmails`, but lost in `properties`.
-        The emailID is needed for dealing with contact groups, so we need a way to recover it from `properties`
-        To do that, we use the fact that for a given user, the email properties appear in the same order as
-        in the variable `filteredContactEmails`. We add the contactEmail to these email properties
-    */
-    const reservoir = [...filteredContactEmails];
-    const mapContactEmails = allProperties.map((property) =>
-        property.field === 'email' ? reservoir.shift() : undefined
-    );
-    const properties = allProperties
-        .map((property, i) => (field === 'email' ? { ...property, contactEmail: mapContactEmails[i] } : property))
-        .filter(({ field }) => fields.includes(field));
+    const properties = allProperties.filter(({ field }) => fields.includes(field));
 
     if (!properties.length) {
         return null;
@@ -55,9 +41,14 @@ const ContactViewProperties = ({ properties: allProperties, contactID, field }) 
             </h3>
             {properties.map((property, index) => {
                 return (
+                    /*
+                        Here we are hiddenly using the fact that the emails in
+                        `properties` appear in the same order as in `contactEmails`
+                    */
                     <ContactViewProperty
                         key={index.toString()}
                         contactID={contactID}
+                        contactEmail={contactEmails && contactEmails[index]}
                         property={property}
                         properties={allProperties}
                     />
@@ -69,7 +60,8 @@ const ContactViewProperties = ({ properties: allProperties, contactID, field }) 
 
 ContactViewProperties.propTypes = {
     properties: PropTypes.array,
-    contactID: PropTypes.string,
+    contactID: PropTypes.string.isRequired,
+    contactEmails: PropTypes.arrayOf(PropTypes.object),
     field: PropTypes.string
 };
 

--- a/src/app/components/ContactViewProperties.js
+++ b/src/app/components/ContactViewProperties.js
@@ -14,7 +14,7 @@ const ICONS = {
     other: 'info'
 };
 
-const ContactViewProperties = ({ properties: allProperties, contactID, contactEmails, field }) => {
+const ContactViewProperties = ({ properties: allProperties, contactID, contactEmails, contactGroupsMap, field }) => {
     const TITLES = {
         email: c('Title').t`Email addresses`,
         tel: c('Title').t`Phone numbers`,
@@ -40,6 +40,9 @@ const ContactViewProperties = ({ properties: allProperties, contactID, contactEm
                 {field === 'email' ? null : <EncryptedIcon />}
             </h3>
             {properties.map((property, index) => {
+                const contactEmail = contactEmails && contactEmails[index];
+                const contactGroups = contactEmail && contactEmail.LabelIDs.map((ID) => contactGroupsMap[ID]);
+
                 return (
                     /*
                         Here we are hiddenly using the fact that the emails in
@@ -48,7 +51,8 @@ const ContactViewProperties = ({ properties: allProperties, contactID, contactEm
                     <ContactViewProperty
                         key={index.toString()}
                         contactID={contactID}
-                        contactEmail={contactEmails && contactEmails[index]}
+                        contactEmail={contactEmail}
+                        contactGroups={contactGroups}
                         property={property}
                         properties={allProperties}
                     />
@@ -62,6 +66,7 @@ ContactViewProperties.propTypes = {
     properties: PropTypes.array,
     contactID: PropTypes.string.isRequired,
     contactEmails: PropTypes.arrayOf(PropTypes.object),
+    contactGroupsMap: PropTypes.object,
     field: PropTypes.string
 };
 

--- a/src/app/components/ContactViewProperty.js
+++ b/src/app/components/ContactViewProperty.js
@@ -11,8 +11,8 @@ import ContactLabelProperty from './ContactLabelProperty';
 import ContactEmailSettingsModal from './ContactEmailSettingsModal';
 import { toMap } from 'proton-shared/lib/helpers/object';
 
-const ContactViewProperty = ({ property, properties, contactID }) => {
-    const { field, first, contactEmail } = property;
+const ContactViewProperty = ({ property, properties, contactID, contactEmail }) => {
+    const { field, first } = property;
     const [{ hasPaidMail }] = useUser();
     const { createModal } = useModals();
     const [contactGroups] = useContactGroups();
@@ -121,7 +121,8 @@ const ContactViewProperty = ({ property, properties, contactID }) => {
 ContactViewProperty.propTypes = {
     property: PropTypes.object.isRequired,
     properties: PropTypes.array,
-    contactID: PropTypes.string
+    contactID: PropTypes.string.isRequired,
+    contactEmail: PropTypes.object
 };
 
 export default ContactViewProperty;

--- a/src/app/components/ContactViewProperty.js
+++ b/src/app/components/ContactViewProperty.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import { Row, Group, ButtonGroup, Copy, useModals, useUser, useContactGroups, classnames } from 'react-components';
+import { Row, Group, ButtonGroup, Copy, useModals, useUser, classnames } from 'react-components';
 import { c } from 'ttag';
 
 import { clearType, getType, formatAdr } from '../helpers/property';
@@ -9,14 +9,11 @@ import ContactGroupIcon from './ContactGroupIcon';
 import ContactGroupDropdown from './ContactGroupDropdown';
 import ContactLabelProperty from './ContactLabelProperty';
 import ContactEmailSettingsModal from './ContactEmailSettingsModal';
-import { toMap } from 'proton-shared/lib/helpers/object';
 
-const ContactViewProperty = ({ property, properties, contactID, contactEmail }) => {
+const ContactViewProperty = ({ property, properties, contactID, contactEmail, contactGroups }) => {
     const { field, first } = property;
     const [{ hasPaidMail }] = useUser();
     const { createModal } = useModals();
-    const [contactGroups] = useContactGroups();
-    const mapContactGroups = toMap(contactGroups);
     const type = clearType(getType(property.type));
     const value = property.value;
 
@@ -28,12 +25,9 @@ const ContactViewProperty = ({ property, properties, contactID, contactEmail }) 
                         <a className="mr0-5" href={`mailto:${value}`} title={value}>
                             {value}
                         </a>
-                        {contactEmail &&
-                            contactEmail.LabelIDs.length > 0 &&
-                            contactEmail.LabelIDs.map((ID) => {
-                                const { Name, Color } = mapContactGroups[ID];
-                                return <ContactGroupIcon key={ID} name={Name} color={Color} />;
-                            })}
+                        {contactGroups.map(({ ID, Name, Color }) => (
+                            <ContactGroupIcon key={ID} name={Name} color={Color} />
+                        ))}
                     </>
                 );
             }
@@ -122,7 +116,8 @@ ContactViewProperty.propTypes = {
     property: PropTypes.object.isRequired,
     properties: PropTypes.array,
     contactID: PropTypes.string.isRequired,
-    contactEmail: PropTypes.object
+    contactEmail: PropTypes.object,
+    contactGroups: PropTypes.arrayOf(PropTypes.object)
 };
 
 export default ContactViewProperty;

--- a/src/app/components/ContactViewProperty.js
+++ b/src/app/components/ContactViewProperty.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import { Row, Group, ButtonGroup, Copy, useModals, useUser, useContactEmails, classnames } from 'react-components';
-import { normalize } from 'proton-shared/lib/helpers/string';
+import { Row, Group, ButtonGroup, Copy, useModals, useUser, useContactGroups, classnames } from 'react-components';
 import { c } from 'ttag';
 
 import { clearType, getType, formatAdr } from '../helpers/property';
@@ -10,12 +9,14 @@ import ContactGroupIcon from './ContactGroupIcon';
 import ContactGroupDropdown from './ContactGroupDropdown';
 import ContactLabelProperty from './ContactLabelProperty';
 import ContactEmailSettingsModal from './ContactEmailSettingsModal';
+import { toMap } from 'proton-shared/lib/helpers/object';
 
 const ContactViewProperty = ({ property, properties, contactID }) => {
-    const { field, first } = property;
+    const { field, first, contactEmail } = property;
     const [{ hasPaidMail }] = useUser();
     const { createModal } = useModals();
-    const [contactEmails] = useContactEmails();
+    const [contactGroups] = useContactGroups();
+    const mapContactGroups = toMap(contactGroups);
     const type = clearType(getType(property.type));
     const value = property.value;
 
@@ -27,11 +28,12 @@ const ContactViewProperty = ({ property, properties, contactID }) => {
                         <a className="mr0-5" href={`mailto:${value}`} title={value}>
                             {value}
                         </a>
-                        {property.contactGroups.length
-                            ? property.contactGroups.map(({ Name, Color, ID }) => (
-                                  <ContactGroupIcon key={ID} name={Name} color={Color} />
-                              ))
-                            : null}
+                        {contactEmail &&
+                            contactEmail.LabelIDs.length > 0 &&
+                            contactEmail.LabelIDs.map((ID) => {
+                                const { Name, Color } = mapContactGroups[ID];
+                                return <ContactGroupIcon key={ID} name={Name} color={Color} />;
+                            })}
                     </>
                 );
             }
@@ -64,8 +66,6 @@ const ContactViewProperty = ({ property, properties, contactID }) => {
     const getActions = () => {
         switch (field) {
             case 'email': {
-                const contactEmail = contactEmails.find(({ Email = '' }) => Email === normalize(value));
-
                 if (!contactEmail) {
                     return null;
                 }

--- a/src/app/components/SelectEmailsModal.js
+++ b/src/app/components/SelectEmailsModal.js
@@ -31,8 +31,8 @@ const SelectEmailsModal = ({ contacts, onSubmit, ...rest }) => {
             });
             return acc;
         }, []);
-        rest.onClose();
         onSubmit(toSubmit);
+        rest.onClose();
     };
 
     const handleCheck = (contactID, contactEmailID) => ({ target }) => {

--- a/src/app/containers/ContactsContainer.js
+++ b/src/app/containers/ContactsContainer.js
@@ -21,6 +21,7 @@ import {
 } from 'react-components';
 import { clearContacts, deleteContacts } from 'proton-shared/lib/api/contacts';
 import { normalize } from 'proton-shared/lib/helpers/string';
+import { toMap } from 'proton-shared/lib/helpers/object';
 
 import ContactsList from '../components/ContactsList';
 import Contact from '../components/Contact';
@@ -82,6 +83,8 @@ const ContactsContainer = ({ location, history }) => {
             return acc;
         }, Object.create(null));
     }, [contactEmails]);
+
+    const contactGroupsMap = useMemo(() => toMap(contactGroups), [contactGroups]);
 
     const formattedContacts = useMemo(() => {
         return filteredContacts.map((contact) => {
@@ -220,6 +223,7 @@ const ContactsContainer = ({ location, history }) => {
                                                     <Contact
                                                         contactID={contactID}
                                                         contactEmails={contactEmailsMap[contactID]}
+                                                        contactGroupsMap={contactGroupsMap}
                                                         userKeysList={userKeysList}
                                                     />
                                                 )}

--- a/src/app/containers/ContactsContainer.js
+++ b/src/app/containers/ContactsContainer.js
@@ -217,7 +217,11 @@ const ContactsContainer = ({ location, history }) => {
                                                         onUncheck={handleUncheckAll}
                                                     />
                                                 ) : (
-                                                    <Contact contactID={contactID} userKeysList={userKeysList} />
+                                                    <Contact
+                                                        contactID={contactID}
+                                                        contactEmails={contactEmailsMap[contactID]}
+                                                        userKeysList={userKeysList}
+                                                    />
                                                 )}
                                             </>
                                         );


### PR DESCRIPTION
* Issue #130 was simply provoked by having two functions called in inverted order, so that it's simple to fix.
* The icons for contact groups were not being displayed properly in some cases because the emails were being matched with email IDs based on the email address (that works fine as long as there are no email collisions for a given user). I changed that match so that emails are always identified by email ID.

Closes #130 