### PR TITLE
Align buttons in ContactPlaceholder

### DIFF
--- a/src/app/components/ContactPlaceholder.js
+++ b/src/app/components/ContactPlaceholder.js
@@ -31,7 +31,7 @@ const PaidCards = ({ contactGroupID, userKeysList, loadingUserKeys }) => {
                     <PrimaryButton className="bold" onClick={handleImport}>{c('Action').t`Import`}</PrimaryButton>
                 </div>
             </div>
-            <div className="bordered-container flex-item-fluid mr1 p1 aligncenter">
+            <div className="bordered-container flex-item-fluid mr1 p1 aligncenter flex flex-column">
                 <div className="flex-item-fluid">
                     <Icon name="export" className="icon-100p mb1" />
                     <div className="bold">{c('Title').t`Export contacts`}</div>


### PR DESCRIPTION
The buttons in ContactPlaceholder are misaligned:
![image](https://user-images.githubusercontent.com/33841139/64354630-173d9500-d000-11e9-8e92-fca5dbaf344d.png)

The button for import has a couple of classes (`flex` and `flex-column`) that aligns it with the groups button, but that class is missing for the export, which is therefore not aligned. If that class is added, all buttons become aligned:
![image](https://user-images.githubusercontent.com/33841139/64354998-b8c4e680-d000-11e9-9442-3880f70890d1.png)

I'm not sure whether this could be achieved without so many classes though.