### PR TITLE
Center autosave toggle

### DIFF
--- a/src/app/components/ContactsSection.js
+++ b/src/app/components/ContactsSection.js
@@ -8,8 +8,8 @@ const ContactsSection = () => {
         <>
             <SubTitle>{c('Title').t`Contacts`}</SubTitle>
             <Row>
-                <Label htmlFor="saveContactToggle">
-                    <span className="mr0-5">{c('Label').t`Automatically save contacts`}</span>
+                <Label htmlFor="saveContactToggle" className="flex flex-nowrap">
+                    <span className="mr0-5 flex flex-items-center">{c('Label').t`Automatically save contacts`}</span>
                     <Info url="https://protonmail.com/support/knowledge-base/autosave-contact-list/" />
                 </Label>
                 <Field>


### PR DESCRIPTION
Mat asked for the autosave contacts toggle to be centered with the text. In `protonmail-settings` this is not happening anywhere right now.

![image](https://user-images.githubusercontent.com/33841139/66395543-f9d16180-e9d7-11e9-9919-5f3e8c420153.png)
