### PR TITLE
Fix upgrade modal not closing

### DIFF
--- a/src/app/components/ContactModal.js
+++ b/src/app/components/ContactModal.js
@@ -1,15 +1,6 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import {
-    FormModal,
-    Alert,
-    useUser,
-    useApi,
-    useUserKeys,
-    useEventManager,
-    useNotifications,
-    useModals
-} from 'react-components';
+import { FormModal, Alert, useUser, useApi, useUserKeys, useEventManager, useNotifications } from 'react-components';
 import { c } from 'ttag';
 import { addContacts } from 'proton-shared/lib/api/contacts';
 
@@ -18,7 +9,6 @@ import { randomIntFromInterval } from 'proton-shared/lib/helpers/function';
 import { generateUID } from 'react-components/helpers/component';
 import { prepareContacts } from '../helpers/encrypt';
 import { getEditableFields, getOtherInformationFields } from '../helpers/fields';
-import UpgradeModal from './UpgradeModal';
 import UpsellFree from './UpsellFree';
 
 const DEFAULT_MODEL = [{ field: 'fn', value: '' }, { field: 'email', value: '' }];
@@ -37,7 +27,6 @@ const formatModel = (properties = []) => {
 };
 
 const ContactModal = ({ contactID, properties: initialProperties, ...rest }) => {
-    const { createModal } = useModals();
     const api = useApi();
     const { createNotification } = useNotifications();
     const [loading, setLoading] = useState(false);
@@ -46,36 +35,9 @@ const ContactModal = ({ contactID, properties: initialProperties, ...rest }) => 
     const [userKeysList, loadingUserKeys] = useUserKeys(user);
     const [properties, setProperties] = useState(formatModel(initialProperties));
     const title = contactID ? c('Title').t`Edit contact details` : c('Title').t`Add new contact`;
-    const upgradeModalRef = useRef(false);
-
-    const hasRequirement = (field) => {
-        if (['fn', 'email'].includes(field) || user.hasPaidMail) {
-            return true;
-        }
-
-        if (!upgradeModalRef.current) {
-            upgradeModalRef.current = true;
-            createModal(
-                <UpgradeModal
-                    onConfirm={() => {
-                        upgradeModalRef.current = false;
-                    }}
-                    onClose={() => {
-                        upgradeModalRef.current = false;
-                    }}
-                />
-            );
-        }
-
-        return false;
-    };
 
     const handleRemove = (propertyUID) => {
-        const { field } = properties.find(({ uid }) => uid === propertyUID) || {};
-
-        if (hasRequirement(field)) {
-            setProperties(properties.filter(({ uid }) => uid !== propertyUID));
-        }
+        setProperties(properties.filter(({ uid }) => uid !== propertyUID));
     };
 
     const handleAdd = (field) => () => {
@@ -100,7 +62,6 @@ const ContactModal = ({ contactID, properties: initialProperties, ...rest }) => 
     };
 
     const handleChange = ({ uid: propertyUID, value, key = 'value' }) => {
-        const { field } = properties.find(({ uid }) => uid === propertyUID) || {};
         const newProperties = properties.map((property) => {
             if (property.uid === propertyUID) {
                 return {
@@ -110,10 +71,7 @@ const ContactModal = ({ contactID, properties: initialProperties, ...rest }) => 
             }
             return property;
         });
-
-        if (hasRequirement(field)) {
-            setProperties(newProperties);
-        }
+        setProperties(newProperties);
     };
 
     const handleOrderChange = useCallback(

--- a/src/app/components/UpgradeModal.js
+++ b/src/app/components/UpgradeModal.js
@@ -4,7 +4,7 @@ import { c } from 'ttag';
 import { ConfirmModal, Alert } from 'react-components';
 import { redirectTo } from 'proton-shared/lib/helpers/browser';
 
-const UpgradeModal = ({ onConfirm, onClose }) => {
+const UpgradeModal = ({ onConfirm, onClose, ...rest }) => {
     return (
         <ConfirmModal
             title={c('Title').t`Upgrade required`}
@@ -14,6 +14,7 @@ const UpgradeModal = ({ onConfirm, onClose }) => {
             }}
             onClose={onClose}
             confirm={c('Action').t`Upgrade`}
+            {...rest}
         >
             <Alert type="warning">{c('Warning').t`This feature requires a paid Proton account`}</Alert>
         </ConfirmModal>


### PR DESCRIPTION
We need to pass `...rest` to the modal for it to close when no `onClose` is passed.

Also, with the new design it's not necessary anymore to have `UpgradeModal` in `ContactModal`