### PR TITLE
More fixes to the PGP settings modal

### DIFF
--- a/src/app/helpers/pgp.js
+++ b/src/app/helpers/pgp.js
@@ -42,7 +42,7 @@ export const allKeysExpired = async (keys = []) => {
     const keyObjects = keys.map((publicKey) => isExpiredKey(publicKey));
     const isExpired = await Promise.all(keyObjects);
 
-    return isExpired.some((keyExpired) => !keyExpired);
+    return !isExpired.some((keyExpired) => !keyExpired);
 };
 
 /**


### PR DESCRIPTION
* keys were marked invalid incorrectly
* key model must be updated when keys are added

This fixes #216 , but I feel we need a more thorough review of the PGP settings modal. I think the code can be improved and some functionality is lacking (e.g. "set primary" button)