### PR TITLE
Use text in Select in ContactGroupsModal

### DIFF
--- a/src/app/components/ContactGroupModal.js
+++ b/src/app/components/ContactGroupModal.js
@@ -78,7 +78,7 @@ const ContactGroupModal = ({ contactGroupID, ...rest }) => {
     const contactEmailIDs = model.contactEmails.map(({ ID }) => ID);
     const options = contactEmails
         .filter(({ ID }) => !contactEmailIDs.includes(ID))
-        .map(({ ID, Email, Name }) => ({ label: `${Email} ${Name}`, value: ID }));
+        .map(({ ID, Email, Name }) => ({ text: `${Email} ${Name}`, value: ID }));
 
     const handleChangeName = ({ target }) => setModel({ ...model, name: target.value });
     const handleChangeColor = (color) => () => setModel({ ...model, color });


### PR DESCRIPTION
Using `label` in the options passed to `<select>` was driving several browsers (Firefox, Safari) crazy. The text inside the options of the select was displayed white, instead of black. Chrome did not have the problem. The other browsers were re-computing the color, making it white

Fixes #237