### PR TITLE
Center images to align with mail layout

### DIFF
--- a/src/app/components/ContactPlaceholder.js
+++ b/src/app/components/ContactPlaceholder.js
@@ -145,8 +145,8 @@ const ContactPlaceholder = ({
         );
 
         return (
-            <div className="p2 view-column-detail flex-item-fluid scroll-if-needed">
-                <div className="aligncenter">
+            <div className="p2 view-column-detail flex flex-item-fluid scroll-if-needed">
+                <div className="aligncenter center mbauto mtauto">
                     <div className="mb2">{c('Info').jt`You selected ${totalContactsText} from your address book.`}</div>
                     <div className="aligncenter mb2">
                         <img src={contactGroupCard} alt="contact-group-card" />
@@ -204,7 +204,7 @@ const ContactPlaceholder = ({
 
     return (
         <div className="p2 view-column-detail flex-item-fluid scroll-if-needed">
-            <div className="aligncenter">
+            <div className="aligncenter mt2">
                 <h1>{c('Title').t`Contacts`}</h1>
                 <div className="mb2">{c('Info').jt`You have ${boldTotalContacts} in your address book`}</div>
                 <div className="mb1">

--- a/src/app/components/ContactsList.js
+++ b/src/app/components/ContactsList.js
@@ -95,8 +95,12 @@ const ContactsList = ({
         );
 
         return (
-            <div className="p2 aligncenter w100">
-                <IllustrationPlaceholder title={c('Info message').t`Your address book is empty`} url={noContactsImg}>
+            <div className="p2 flex w100">
+                <IllustrationPlaceholder
+                    title={c('Info message').t`Your address book is empty`}
+                    url={noContactsImg}
+                    className="mtauto mbauto"
+                >
                     <div className="flex flex-items-center">
                         {c('Actions message').jt`You can either ${addContact} or ${importContact} from a file.`}
                     </div>

--- a/src/app/containers/ContactsContainer.js
+++ b/src/app/containers/ContactsContainer.js
@@ -51,7 +51,6 @@ const ContactsContainer = ({ location, history }) => {
     const [userKeysList, loadingUserKeys] = useUserKeys(user);
 
     const { isDesktop, isNarrow } = useActiveBreakpoint();
-    const noHeader = isNarrow ? '--noHeader' : '';
 
     const contactGroupID = useMemo(() => {
         const params = new URLSearchParams(location.search);
@@ -211,6 +210,7 @@ const ContactsContainer = ({ location, history }) => {
 
     const isLoading = loadingContactEmails || loadingContacts || loadingContactGroups || loadingUserKeys;
     const contactsLength = contacts ? contacts.length : 0;
+    const noHeader = isNarrow && contactID ? '--noHeader' : '';
 
     const contactComponent = contactID && contactsLength && !hasChecked && (
         <Contact


### PR DESCRIPTION
* center placeholder images (empty address book, group and contact multi-selection)
* add `mt2` css class on welcome message
* also, fix wrong use of `main-area--withToolbar--noHeader`. It must only be used when there's no header