### PR TITLE
Take care of categories when editing / merging contacts

### DIFF
--- a/src/app/components/ContactModal.js
+++ b/src/app/components/ContactModal.js
@@ -22,15 +22,10 @@ import { getEditableFields, getOtherInformationFields } from '../helpers/fields'
 import { OVERWRITE, CATEGORIES, SUCCESS_IMPORT_CODE } from '../constants';
 
 import UpsellFree from './UpsellFree';
-import { CATEGORIES } from '../constants';
 
 const DEFAULT_MODEL = [{ field: 'fn', value: '' }, { field: 'email', value: '' }];
-<<<<<<< HEAD
 const { OVERWRITE_CONTACT, THROW_ERROR_IF_CONFLICT } = OVERWRITE;
-const { IGNORE } = CATEGORIES;
-=======
 const { INCLUDE, IGNORE } = CATEGORIES;
->>>>>>> take care of categories when editing / merging contacts
 
 const editableFields = getEditableFields().map(({ value }) => value);
 const otherInformationFields = getOtherInformationFields().map(({ value }) => value);

--- a/src/app/components/ContactModal.js
+++ b/src/app/components/ContactModal.js
@@ -17,14 +17,20 @@ import ContactModalProperties from './ContactModalProperties';
 import { randomIntFromInterval } from 'proton-shared/lib/helpers/function';
 import { generateUID } from 'react-components/helpers/component';
 import { prepareContacts } from '../helpers/encrypt';
+import { hasCategories } from '../helpers/import';
 import { getEditableFields, getOtherInformationFields } from '../helpers/fields';
 import { OVERWRITE, CATEGORIES, SUCCESS_IMPORT_CODE } from '../constants';
 
 import UpsellFree from './UpsellFree';
+import { CATEGORIES } from '../constants';
 
 const DEFAULT_MODEL = [{ field: 'fn', value: '' }, { field: 'email', value: '' }];
+<<<<<<< HEAD
 const { OVERWRITE_CONTACT, THROW_ERROR_IF_CONFLICT } = OVERWRITE;
 const { IGNORE } = CATEGORIES;
+=======
+const { INCLUDE, IGNORE } = CATEGORIES;
+>>>>>>> take care of categories when editing / merging contacts
 
 const editableFields = getEditableFields().map(({ value }) => value);
 const otherInformationFields = getOtherInformationFields().map(({ value }) => value);
@@ -68,13 +74,14 @@ const ContactModal = ({ contactID, properties: initialProperties = [], history, 
     const handleSubmit = async () => {
         const notEditableProperties = initialProperties.filter(({ field }) => !editableFields.includes(field));
         const Contacts = await prepareContacts([properties.concat(notEditableProperties)], userKeysList[0]);
+        const labels = hasCategories(notEditableProperties) ? INCLUDE : IGNORE;
         const {
             Responses: [{ Response: { Code, Contact: { ID } = {} } = {} }]
         } = await api(
             addContacts({
                 Contacts,
                 Overwrite: contactID ? OVERWRITE_CONTACT : THROW_ERROR_IF_CONFLICT,
-                Labels: IGNORE
+                Labels: labels
             })
         );
         if (Code !== SUCCESS_IMPORT_CODE) {

--- a/src/app/components/import/ImportModal.js
+++ b/src/app/components/import/ImportModal.js
@@ -18,7 +18,7 @@ import ImportingModalContent from './ImportingModalContent';
 import ImportGroupsModalContent from './ImportGroupsModalContent';
 
 // temporarily disabled
-// import { hasCategories } from '../../helpers/import';
+// import { haveCategories } from '../../helpers/import';
 import { readCsv } from '../../helpers/csv';
 import { readVcf } from '../../helpers/vcard';
 import { BASE_SIZE } from 'proton-shared/lib/constants';
@@ -156,7 +156,7 @@ const ImportModal = ({ userKeysList, ...rest }) => {
 
             const handleFinish = async () => {
                 // temporarily disabled
-                // if (hasCategories(vcardContacts)) {
+                // if (haveCategories(vcardContacts)) {
                 //     return setStep(IMPORT_GROUPS);
                 // }
                 await call();

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -37,6 +37,7 @@ export const PGP_INLINE = 'pgp-inline';
 export const PGP_MIME = 'pgp-mime';
 export const PGP_INLINE_TEXT = 'PGP/Inline';
 export const PGP_MIME_TEXT = 'PGP/MIME';
+export const PGP_SIGN = 1;
 
 export const OVERWRITE = {
     // when UID conflict at contact import

--- a/src/app/helpers/import.js
+++ b/src/app/helpers/import.js
@@ -5,13 +5,23 @@ import { CONTACT_CARD_TYPE } from 'proton-shared/lib/constants';
 const { CLEAR_TEXT } = CONTACT_CARD_TYPE;
 
 /**
+ * For a vCard contact, check if it contains categories
+ * @param {Array<Object>} vcardContact       A vCard contact
+ *
+ * @return {Boolean}
+ */
+export const hasCategories = (vcardContact) => {
+    return vcardContact.some(({ field, value }) => value && field === 'categories');
+};
+
+/**
  * For a list of vCard contacts, check if any contains categories
  * @param {Array<Array<Object>>} vcardContacts       Array of vCard contacts
  *
  * @return {Boolean}
  */
-export const hasCategories = (vcardContacts) => {
-    return vcardContacts.some((contact) => contact.some(({ field, value }) => value && field === 'categories'));
+export const haveCategories = (vcardContacts) => {
+    return vcardContacts.some((contact) => hasCategories(contact));
 };
 
 /**


### PR DESCRIPTION
We were not taking care of categories in several places: when editing contacts (`ContactModal`), when editing email settings (`EmailSettingsModal`), and when merging contacts (`MergingModalContent`). This PR fixes that and polishes the code a little bit

Fixes #270