### PR TITLE
Fix bug with select all

### DIFF
--- a/src/app/containers/ContactsContainer.js
+++ b/src/app/containers/ContactsContainer.js
@@ -186,7 +186,7 @@ const ContactsContainer = ({ location, history }) => {
         if (!Array.isArray(contacts)) {
             return;
         }
-        handleCheck(contacts.map(({ ID }) => ID), checked);
+        handleCheck(filteredContacts.map(({ ID }) => ID), checked);
     };
 
     const handleUncheckAll = () => {


### PR DESCRIPTION
Select all should only select filtered contacts. Right now it was selecting everything even if only the filtered contacts are shown in the screen, leading to very dangerous situations (like erasing all contacts by mistake)