### PR TITLE
Improve UX for pictures in ContactModal

### DIFF
--- a/src/app/components/ContactFieldProperty.js
+++ b/src/app/components/ContactFieldProperty.js
@@ -7,7 +7,7 @@ import ContactImageField from './ContactImageField';
 import ContactAdrField from './ContactAdrField';
 import { getAllFieldLabels } from '../helpers/fields';
 
-const ContactFieldProperty = ({ field, value, uid, onChange, ...rest }) => {
+const ContactFieldProperty = ({ field, value, uid, onChange, onChangeImage, ...rest }) => {
     const handleChange = ({ target }) => onChange({ value: target.value, uid });
     const labels = getAllFieldLabels();
 
@@ -46,7 +46,7 @@ const ContactFieldProperty = ({ field, value, uid, onChange, ...rest }) => {
     }
 
     if (field === 'photo' || field === 'logo') {
-        const handleChangeImage = (url) => onChange({ value: url, uid });
+        const handleChangeImage = (url) => onChangeImage({ value: url, uid });
         return <ContactImageField value={value} onChange={handleChangeImage} {...rest} />;
     }
     return <Input value={value} placeholder={labels[field]} onChange={handleChange} {...rest} />;
@@ -56,7 +56,8 @@ ContactFieldProperty.propTypes = {
     field: PropTypes.string.isRequired,
     uid: PropTypes.string.isRequired,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string), PropTypes.object]),
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    onChangeImage: PropTypes.func
 };
 
 export default ContactFieldProperty;

--- a/src/app/components/ContactFieldProperty.js
+++ b/src/app/components/ContactFieldProperty.js
@@ -1,15 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { Input, TextArea, EmailInput, DateInput, TelInput } from 'react-components';
+import { useModals, Input, TextArea, EmailInput, DateInput, TelInput } from 'react-components';
+import { getAllFieldLabels } from '../helpers/fields';
 
 import ContactImageField from './ContactImageField';
 import ContactAdrField from './ContactAdrField';
-import { getAllFieldLabels } from '../helpers/fields';
+import ContactImageModal from './ContactImageModal';
 
-const ContactFieldProperty = ({ field, value, uid, onChange, onChangeImage, ...rest }) => {
-    const handleChange = ({ target }) => onChange({ value: target.value, uid });
+const ContactFieldProperty = ({ field, value, uid, onChange, ...rest }) => {
+    const { createModal } = useModals();
     const labels = getAllFieldLabels();
+
+    const handleChange = ({ target }) => onChange({ value: target.value, uid });
 
     if (field === 'email') {
         return <EmailInput value={value} placeholder={labels.email} onChange={handleChange} {...rest} />;
@@ -46,7 +49,10 @@ const ContactFieldProperty = ({ field, value, uid, onChange, onChangeImage, ...r
     }
 
     if (field === 'photo' || field === 'logo') {
-        const handleChangeImage = (url) => onChangeImage({ value: url, uid });
+        const handleChangeImage = () => {
+            const handleSubmit = (value) => onChange({ uid, value });
+            createModal(<ContactImageModal url={value} onSubmit={handleSubmit} />);
+        };
         return <ContactImageField value={value} onChange={handleChangeImage} {...rest} />;
     }
     return <Input value={value} placeholder={labels[field]} onChange={handleChange} {...rest} />;
@@ -56,8 +62,7 @@ ContactFieldProperty.propTypes = {
     field: PropTypes.string.isRequired,
     uid: PropTypes.string.isRequired,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string), PropTypes.object]),
-    onChange: PropTypes.func.isRequired,
-    onChangeImage: PropTypes.func
+    onChange: PropTypes.func.isRequired
 };
 
 export default ContactFieldProperty;

--- a/src/app/components/ContactImageField.js
+++ b/src/app/components/ContactImageField.js
@@ -1,12 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Icon, RemoteImage } from 'react-components';
+import { c } from 'ttag';
+import { Button, img } from 'react-components';
 
-const ContactImageField = ({ value }) => {
-    return <div className="mb1">{value ? <RemoteImage src={value} /> : <Icon name="contact" size={40} />}</div>;
+const ContactImageField = ({ value, onChange }) => {
+    return (
+        <div className="mb1">
+            {value ? <img src={value} /> : <Button onClick={onChange}>{c('Action').t`Upload picture`}</Button>}
+        </div>
+    );
 };
 
 ContactImageField.propTypes = {
+    show: PropTypes.bool,
     value: PropTypes.string,
     onChange: PropTypes.func
 };

--- a/src/app/components/ContactImageModal.js
+++ b/src/app/components/ContactImageModal.js
@@ -28,7 +28,7 @@ const ContactImageModal = ({ url: initialUrl, onSubmit, onClose, ...rest }) => {
                     maxHeight: CONTACT_IMG_SIZE,
                     finalMimeType: 'image/jpeg',
                     encoderOptions: 1,
-                    invert: true
+                    bigResize: true
                 });
                 onSubmit(base64str);
                 onClose();

--- a/src/app/components/ContactImageModal.js
+++ b/src/app/components/ContactImageModal.js
@@ -22,7 +22,14 @@ const ContactImageModal = ({ url: initialUrl, onSubmit, onClose, ...rest }) => {
 
         reader.onloadend = async () => {
             try {
-                const base64str = await resizeImage(reader.result, CONTACT_IMG_SIZE, 'image/jpeg', 0.7);
+                const base64str = await resizeImage({
+                    original: reader.result,
+                    maxWidth: CONTACT_IMG_SIZE,
+                    maxHeight: CONTACT_IMG_SIZE,
+                    finalMimeType: 'image/jpeg',
+                    encoderOptions: 1,
+                    invert: true
+                });
                 onSubmit(base64str);
                 onClose();
             } catch (error) {

--- a/src/app/components/ContactImageSummary.js
+++ b/src/app/components/ContactImageSummary.js
@@ -1,16 +1,33 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { c } from 'ttag';
 import PropTypes from 'prop-types';
-import { useMailSettings, Button } from 'react-components';
+import { useMailSettings, useLoading, Loader, Button } from 'react-components';
 import { getInitial } from 'proton-shared/lib/helpers/string';
 import { isURL } from 'proton-shared/lib/helpers/validators';
 import { SHOW_IMAGES } from 'proton-shared/lib/constants';
+import { resizeImage } from 'proton-shared/lib/helpers/image';
 
-const ContactImageSummary = ({ src, name }) => {
-    const [{ ShowImages }, loading] = useMailSettings();
-    const [showAnyways, setShowAnyways] = useState(!isURL(src));
+const ContactImageSummary = ({ photo, name }) => {
+    const [showAnyways, setShowAnyways] = useState(!isURL(photo));
+    const [src, setSrc] = useState(photo);
+    const [{ ShowImages }, loadingMailSettings] = useMailSettings();
+    const [loadingResize, withLoadingResize] = useLoading();
+    const loading = loadingMailSettings && loadingResize;
 
-    if (!src) {
+    useEffect(() => {
+        const resize = async () => {
+            const resizedImage = await resizeImage({
+                original: photo,
+                maxWidth: 180,
+                maxHeight: 180,
+                smallResize: true
+            });
+            setSrc(resizedImage);
+        };
+        withLoadingResize(resize());
+    }, [photo]);
+
+    if (!photo) {
         return (
             <div className="rounded50 bordered bg-white ratio-container-square mb0">
                 <span className="inner-ratio-container flex">
@@ -22,12 +39,20 @@ const ContactImageSummary = ({ src, name }) => {
 
     const handleClick = () => setShowAnyways(true);
 
-    if ((!loading && ShowImages & SHOW_IMAGES.REMOTE) || showAnyways) {
+    if (ShowImages & SHOW_IMAGES.REMOTE || showAnyways) {
+        if (loading) {
+            return <Loader />;
+        }
+
+        const style = {
+            backgroundImage: `url(${src})`,
+            backgroundPosition: 'center',
+            backgroundRepeat: 'no-repeat'
+        };
+
         return (
-            <div className="rounded50 ratio-container-square">
-                <span className="inner-ratio-container">
-                    <img src={src} className="rounded50 h100 w100" />
-                </span>
+            <div className="rounded50 ratio-container-square" style={style}>
+                <span className="inner-ratio-container"></span>
             </div>
         );
     }
@@ -43,7 +68,7 @@ const ContactImageSummary = ({ src, name }) => {
     );
 };
 ContactImageSummary.propTypes = {
-    src: PropTypes.string,
+    photo: PropTypes.string,
     name: PropTypes.string
 };
 

--- a/src/app/components/ContactImageSummary.js
+++ b/src/app/components/ContactImageSummary.js
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { c } from 'ttag';
+import PropTypes from 'prop-types';
+import { useMailSettings, Button } from 'react-components';
+import { getInitial } from 'proton-shared/lib/helpers/string';
+import { isURL } from 'proton-shared/lib/helpers/validators';
+import { SHOW_IMAGES } from 'proton-shared/lib/constants';
+
+const ContactImageSummary = ({ src, name }) => {
+    const [{ ShowImages }, loading] = useMailSettings();
+    const [showAnyways, setShowAnyways] = useState(!isURL(src));
+
+    if (!src) {
+        return (
+            <div className="rounded50 bordered bg-white ratio-container-square mb0">
+                <span className="inner-ratio-container flex">
+                    <span className="mauto color-global-border h1">{getInitial(name)}</span>
+                </span>
+            </div>
+        );
+    }
+
+    const handleClick = () => setShowAnyways(true);
+
+    if ((!loading && ShowImages & SHOW_IMAGES.REMOTE) || showAnyways) {
+        return (
+            <div className="rounded50 ratio-container-square">
+                <span className="inner-ratio-container">
+                    <img src={src} className="rounded50 h100 w100" />
+                </span>
+            </div>
+        );
+    }
+
+    return (
+        <div className="rounded50 bordered bg-white ratio-container-square mb0">
+            <span className="inner-ratio-container flex">
+                <span className="mauto color-global-border">
+                    <Button onClick={handleClick}>{c('Action').t`Load photo`}</Button>
+                </span>
+            </span>
+        </div>
+    );
+};
+ContactImageSummary.propTypes = {
+    src: PropTypes.string,
+    name: PropTypes.string
+};
+
+export default ContactImageSummary;

--- a/src/app/components/ContactImageSummary.js
+++ b/src/app/components/ContactImageSummary.js
@@ -20,7 +20,7 @@ const ContactImageSummary = ({ photo, name }) => {
             const { width, height } = await toImage(photo);
             setImage((image) => ({ ...image, width, height }));
 
-            if (width < CONTACT_IMG_SIZE && height < CONTACT_IMG_SIZE) {
+            if (width <= CONTACT_IMG_SIZE && height <= CONTACT_IMG_SIZE) {
                 return setImage((image) => ({ ...image, isSmall: true }));
             }
             const resized = await resizeImage({

--- a/src/app/components/ContactModalRow.js
+++ b/src/app/components/ContactModalRow.js
@@ -10,18 +10,21 @@ import ContactImageModal from './ContactImageModal';
 
 const ContactModalRow = ({ property, onChange, onRemove, isOrderable = false }) => {
     const { createModal } = useModals();
-    const { field, uid } = property;
+    const { field, uid, value } = property;
     const type = clearType(getType(property.type));
     const canDelete = !['fn'].includes(field);
     const canClear = ['photo', 'logo'].includes(field) && property.value;
-    const canEdit = ['photo', 'logo'].includes(field);
+    const canEdit = ['photo', 'logo'].includes(field) && !!value;
+
+    const handleChangeImage = () => {
+        const handleSubmit = (value) => onChange({ uid, value });
+        createModal(<ContactImageModal url={property.value} onSubmit={handleSubmit} />);
+    };
 
     const list = [
-        canDelete && {
-            text: c('Action').t`Delete`,
-            onClick() {
-                onRemove(property.uid);
-            }
+        canEdit && {
+            text: c('Action').t`Edit`,
+            onClick: handleChangeImage
         },
         canClear && {
             text: c('Action').t`Clear`,
@@ -29,11 +32,10 @@ const ContactModalRow = ({ property, onChange, onRemove, isOrderable = false }) 
                 onChange({ uid, value: '' });
             }
         },
-        canEdit && {
-            text: c('Action').t`Edit`,
+        canDelete && {
+            text: c('Action').t`Delete`,
             onClick() {
-                const handleSubmit = (value) => onChange({ uid, value });
-                createModal(<ContactImageModal url={property.value} onSubmit={handleSubmit} />);
+                onRemove(property.uid);
             }
         }
     ].filter(Boolean);
@@ -62,6 +64,7 @@ const ContactModalRow = ({ property, onChange, onRemove, isOrderable = false }) 
                             value={property.value}
                             uid={property.uid}
                             onChange={onChange}
+                            onChangeImage={handleChangeImage}
                         />
                     </Field>
                 </span>

--- a/src/app/components/ContactModalRow.js
+++ b/src/app/components/ContactModalRow.js
@@ -64,7 +64,6 @@ const ContactModalRow = ({ property, onChange, onRemove, isOrderable = false }) 
                             value={property.value}
                             uid={property.uid}
                             onChange={onChange}
-                            onChangeImage={handleChangeImage}
                         />
                     </Field>
                 </span>

--- a/src/app/components/ContactSummary.js
+++ b/src/app/components/ContactSummary.js
@@ -35,7 +35,7 @@ const ContactSummary = ({ properties }) => {
     return (
         <div className="bg-global-light flex flex-nowrap p1 mb1 border-bottom">
             <div className="aligncenter contactsummary-photo-container">
-                <ContactImageSummary src={photo} name={name} />
+                <ContactImageSummary photo={photo} name={name} />
             </div>
             <div className="pl1">
                 <h2 className="mb0-5 ellipsis">{name}</h2>

--- a/src/app/components/ContactSummary.js
+++ b/src/app/components/ContactSummary.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Icon, RemoteImage, useUser } from 'react-components';
-import { getInitial } from 'proton-shared/lib/helpers/string';
+import { Icon, useUser } from 'react-components';
 
 import { getFirstValue } from '../helpers/properties';
 import { formatAdr } from '../helpers/property';
 
+import ContactImageSummary from './ContactImageSummary';
 import './ContactSummary.scss';
 
 const ContactSummary = ({ properties }) => {
@@ -35,15 +35,7 @@ const ContactSummary = ({ properties }) => {
     return (
         <div className="bg-global-light flex flex-nowrap p1 mb1 border-bottom">
             <div className="aligncenter contactsummary-photo-container">
-                {photo ? (
-                    <RemoteImage src={photo} className="rounded50" />
-                ) : (
-                    <div className="rounded50 bordered bg-white ratio-container-square mb0">
-                        <span className="inner-ratio-container flex">
-                            <span className="mauto color-global-border h1">{getInitial(name)}</span>
-                        </span>
-                    </div>
-                )}
+                <ContactImageSummary src={photo} name={name} />
             </div>
             <div className="pl1">
                 <h2 className="mb0-5 ellipsis">{name}</h2>

--- a/src/app/components/ContactViewProperty.js
+++ b/src/app/components/ContactViewProperty.js
@@ -1,7 +1,18 @@
 import React from 'react';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import { Row, Group, ButtonGroup, Copy, Icon, useModals, useUser, classnames, Tooltip } from 'react-components';
+import {
+    Row,
+    Group,
+    ButtonGroup,
+    Copy,
+    Icon,
+    useModals,
+    useUser,
+    classnames,
+    Tooltip,
+    RemoteImage
+} from 'react-components';
 import { c } from 'ttag';
 
 import { clearType, getType, formatAdr } from '../helpers/property';
@@ -48,7 +59,7 @@ const ContactViewProperty = ({ property, properties, contactID, contactEmail, co
             return value;
         }
         if (field === 'logo') {
-            return <img src={value} alt={field} />;
+            return <RemoteImage src={value} />;
         }
         if (field === 'adr') {
             return formatAdr(value);

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -1,4 +1,4 @@
-export const CONTACT_IMG_SIZE = 128;
+export const CONTACT_IMG_SIZE = 180;
 export const POST_BOX = 0;
 export const EXTENDED = 1;
 export const STREET = 2;

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -1,4 +1,4 @@
-export const CONTACT_IMG_SIZE = 180;
+export const CONTACT_IMG_SIZE = 180; // size in px that we display in desktop view
 export const POST_BOX = 0;
 export const EXTENDED = 1;
 export const STREET = 2;


### PR DESCRIPTION
Implement the suggestions in #231.

For non-square pictures, like 
![ugly_cat](https://user-images.githubusercontent.com/33841139/67880250-90f48980-fb3e-11e9-9c3b-4a31e0f278d8.jpeg)
, we select a circle in the center:
![image](https://user-images.githubusercontent.com/33841139/67880397-d9ac4280-fb3e-11e9-82b2-36fc3d5c20b2.png)

If the image is smaller, we keep the circular shape, but obviously it must be smaller:
![image](https://user-images.githubusercontent.com/33841139/67880465-f2b4f380-fb3e-11e9-9b56-20b2fecd8ad0.png)


Closes #231. Closes #195.