### PR TITLE
Remain in group after contact delete

### DIFF
--- a/src/app/components/ContactModal.js
+++ b/src/app/components/ContactModal.js
@@ -19,7 +19,7 @@ import { generateUID } from 'react-components/helpers/component';
 import { prepareContacts } from '../helpers/encrypt';
 import { hasCategories } from '../helpers/import';
 import { getEditableFields, getOtherInformationFields } from '../helpers/fields';
-import { OVERWRITE, CATEGORIES, SUCCESS_IMPORT_CODE } from '../constants';
+import { OVERWRITE, CATEGORIES, SUCCESS_API_CODE } from '../constants';
 
 import UpsellFree from './UpsellFree';
 
@@ -79,7 +79,7 @@ const ContactModal = ({ contactID, properties: initialProperties = [], history, 
                 Labels: labels
             })
         );
-        if (Code !== SUCCESS_IMPORT_CODE) {
+        if (Code !== SUCCESS_API_CODE) {
             rest.onClose();
             return createNotification({ text: c('Error').t`Contact could not be saved`, type: 'error' });
         }

--- a/src/app/components/ContactModal.js
+++ b/src/app/components/ContactModal.js
@@ -19,13 +19,15 @@ import { generateUID } from 'react-components/helpers/component';
 import { prepareContacts } from '../helpers/encrypt';
 import { hasCategories } from '../helpers/import';
 import { getEditableFields, getOtherInformationFields } from '../helpers/fields';
-import { OVERWRITE, CATEGORIES, SUCCESS_API_CODE } from '../constants';
+import { OVERWRITE, CATEGORIES } from '../constants';
+import { API_CODES } from 'proton-shared/lib/constants';
 
 import UpsellFree from './UpsellFree';
 
 const DEFAULT_MODEL = [{ field: 'fn', value: '' }, { field: 'email', value: '' }];
 const { OVERWRITE_CONTACT, THROW_ERROR_IF_CONFLICT } = OVERWRITE;
 const { INCLUDE, IGNORE } = CATEGORIES;
+const { ARRAY_ELEMENT_SUCCESS } = API_CODES;
 
 const editableFields = getEditableFields().map(({ value }) => value);
 const otherInformationFields = getOtherInformationFields().map(({ value }) => value);
@@ -79,7 +81,7 @@ const ContactModal = ({ contactID, properties: initialProperties = [], history, 
                 Labels: labels
             })
         );
-        if (Code !== SUCCESS_API_CODE) {
+        if (Code !== ARRAY_ELEMENT_SUCCESS) {
             rest.onClose();
             return createNotification({ text: c('Error').t`Contact could not be saved`, type: 'error' });
         }

--- a/src/app/components/import/ImportingModalContent.js
+++ b/src/app/components/import/ImportingModalContent.js
@@ -13,7 +13,7 @@ import { extractVcards, parse as parseVcard } from '../../helpers/vcard';
 import { prepareContact } from '../../helpers/encrypt';
 import { splitContacts } from '../../helpers/import';
 import { combineProgress } from '../../helpers/progress';
-import { OVERWRITE, CATEGORIES, SUCCESS_IMPORT_CODE, API_SAFE_INTERVAL, ADD_CONTACTS_MAX_SIZE } from '../../constants';
+import { OVERWRITE, CATEGORIES, SUCCESS_API_CODE, API_SAFE_INTERVAL, ADD_CONTACTS_MAX_SIZE } from '../../constants';
 
 const { OVERWRITE_CONTACT } = OVERWRITE;
 const { IGNORE, INCLUDE } = CATEGORIES;
@@ -131,7 +131,7 @@ const ImportingModalContent = ({ isVcf, file = '', vcardContacts, privateKey, on
             const { submittedBatch, failedOnSubmitBatch } = responses.reduce(
                 (acc, { Code, Error, Contact: { ID } = {} }, i) => {
                     const index = indexMap[i];
-                    if (Code === SUCCESS_IMPORT_CODE) {
+                    if (Code === SUCCESS_API_CODE) {
                         acc.submittedBatch.push(ID);
                     } else {
                         acc.failedOnSubmitBatch.push({ index, message: createSubmitErrorMessage(index + 1, Error) });

--- a/src/app/components/import/ImportingModalContent.js
+++ b/src/app/components/import/ImportingModalContent.js
@@ -13,10 +13,12 @@ import { extractVcards, parse as parseVcard } from '../../helpers/vcard';
 import { prepareContact } from '../../helpers/encrypt';
 import { splitContacts } from '../../helpers/import';
 import { combineProgress } from '../../helpers/progress';
-import { OVERWRITE, CATEGORIES, SUCCESS_API_CODE, API_SAFE_INTERVAL, ADD_CONTACTS_MAX_SIZE } from '../../constants';
+import { OVERWRITE, CATEGORIES, API_SAFE_INTERVAL, ADD_CONTACTS_MAX_SIZE } from '../../constants';
+import { API_CODES } from 'proton-shared/lib/constants';
 
 const { OVERWRITE_CONTACT } = OVERWRITE;
 const { IGNORE, INCLUDE } = CATEGORIES;
+const { ARRAY_ELEMENT_SUCCESS } = API_CODES;
 
 const createParseErrorMessage = (index, message) =>
     c('Info on errors importing contacts').t`Contact ${index} from your list could not be parsed. ${message}`;
@@ -131,7 +133,7 @@ const ImportingModalContent = ({ isVcf, file = '', vcardContacts, privateKey, on
             const { submittedBatch, failedOnSubmitBatch } = responses.reduce(
                 (acc, { Code, Error, Contact: { ID } = {} }, i) => {
                     const index = indexMap[i];
-                    if (Code === SUCCESS_API_CODE) {
+                    if (Code === ARRAY_ELEMENT_SUCCESS) {
                         acc.submittedBatch.push(ID);
                     } else {
                         acc.failedOnSubmitBatch.push({ index, message: createSubmitErrorMessage(index + 1, Error) });

--- a/src/app/components/merge/MergingModalContent.js
+++ b/src/app/components/merge/MergingModalContent.js
@@ -13,12 +13,14 @@ import { prepareContact as encrypt } from '../../helpers/encrypt';
 import { merge } from '../../helpers/merge';
 import { splitContacts } from '../../helpers/import';
 import { combineProgress } from '../../helpers/progress';
-import { OVERWRITE, CATEGORIES, SUCCESS_API_CODE, API_SAFE_INTERVAL, ADD_CONTACTS_MAX_SIZE } from '../../constants';
+import { OVERWRITE, CATEGORIES, API_SAFE_INTERVAL, ADD_CONTACTS_MAX_SIZE } from '../../constants';
+import { API_CODES } from 'proton-shared/lib/constants';
 
 import DynamicProgress from '../DynamicProgress';
 
 const { OVERWRITE_CONTACT } = OVERWRITE;
 const { INCLUDE, IGNORE } = CATEGORIES;
+const { ARRAY_ELEMENT_SUCCESS } = API_CODES;
 
 const MergingModalContent = ({
     contactID,
@@ -169,7 +171,7 @@ const MergingModalContent = ({
             } of responses) {
                 const groupIDs = beMergedModel[ID];
                 const beDeletedAfterMergeIDs = groupIDs.slice(1);
-                if (Code === SUCCESS_API_CODE) {
+                if (Code === ARRAY_ELEMENT_SUCCESS) {
                     !signal.aborted &&
                         setModel((model) => ({ ...model, submitted: [...model.submitted, ...groupIDs] }));
                     beDeletedBatchIDs.push(...beDeletedAfterMergeIDs);

--- a/src/app/components/merge/MergingModalContent.js
+++ b/src/app/components/merge/MergingModalContent.js
@@ -13,7 +13,7 @@ import { prepareContact as encrypt } from '../../helpers/encrypt';
 import { merge } from '../../helpers/merge';
 import { splitContacts } from '../../helpers/import';
 import { combineProgress } from '../../helpers/progress';
-import { OVERWRITE, CATEGORIES, SUCCESS_IMPORT_CODE, API_SAFE_INTERVAL, ADD_CONTACTS_MAX_SIZE } from '../../constants';
+import { OVERWRITE, CATEGORIES, SUCCESS_API_CODE, API_SAFE_INTERVAL, ADD_CONTACTS_MAX_SIZE } from '../../constants';
 
 import DynamicProgress from '../DynamicProgress';
 
@@ -169,7 +169,7 @@ const MergingModalContent = ({
             } of responses) {
                 const groupIDs = beMergedModel[ID];
                 const beDeletedAfterMergeIDs = groupIDs.slice(1);
-                if (Code === SUCCESS_IMPORT_CODE) {
+                if (Code === SUCCESS_API_CODE) {
                     !signal.aborted &&
                         setModel((model) => ({ ...model, submitted: [...model.submitted, ...groupIDs] }));
                     beDeletedBatchIDs.push(...beDeletedAfterMergeIDs);

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -52,7 +52,6 @@ export const CATEGORIES = {
 
 // BACK-END DATA
 export const API_SAFE_INTERVAL = 100; // API request limit: 100 requests / 10 seconds, so 1 request every 100 ms is safe
-export const SUCCESS_API_CODE = 1000; // in POST API route /contacts
 export const QUERY_EXPORT_MAX_PAGESIZE = 50; // in GET API route /contacts/export
 // Manual limit on number of imported contacts to be sent to the API,
 // so that the response does not take too long (there's a 30s limit)

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -52,7 +52,7 @@ export const CATEGORIES = {
 
 // BACK-END DATA
 export const API_SAFE_INTERVAL = 100; // API request limit: 100 requests / 10 seconds, so 1 request every 100 ms is safe
-export const SUCCESS_IMPORT_CODE = 1000; // in POST API route /contacts
+export const SUCCESS_API_CODE = 1000; // in POST API route /contacts
 export const QUERY_EXPORT_MAX_PAGESIZE = 50; // in GET API route /contacts/export
 // Manual limit on number of imported contacts to be sent to the API,
 // so that the response does not take too long (there's a 30s limit)

--- a/src/app/containers/ContactsContainer.js
+++ b/src/app/containers/ContactsContainer.js
@@ -22,7 +22,7 @@ import { clearContacts, deleteContacts } from 'proton-shared/lib/api/contacts';
 import { normalize } from 'proton-shared/lib/helpers/string';
 import { toMap } from 'proton-shared/lib/helpers/object';
 import { extractMergeable } from '../helpers/merge';
-import { SUCCESS_API_CODE } from '../constants';
+import { allSucceded } from 'proton-shared/lib/api/helpers/response';
 
 import ContactsList from '../components/ContactsList';
 import Contact from '../components/Contact';
@@ -167,13 +167,13 @@ const ContactsContainer = ({ location, history }) => {
             await api(clearContacts());
             return createNotification({ text: c('Success').t`Contacts deleted` });
         }
-        const { Responses } = await api(deleteContacts(activeIDs));
+        const apiResponse = await api(deleteContacts(activeIDs));
         history.push({ ...location, pathname: '/contacts' });
         await call();
         setCheckedContacts(Object.create(null));
         setCheckAll(false);
-        if (Responses.some(({ Response: { Code } }) => Code !== SUCCESS_API_CODE)) {
-            return createNotification({ text: c('Error').t`Some contacts could not be deleted`, type: 'error' });
+        if (!allSucceded(apiResponse)) {
+            return createNotification({ text: c('Error').t`Some contacts could not be deleted`, type: 'warning' });
         }
         createNotification({ text: c('Success').t`Contacts deleted` });
     };


### PR DESCRIPTION
When the user deletes a contact from a contact group, do not navigate away from the group. To achieve that, we can simply keep the contactGroup query parameter in the `location` object.

Also here:
- Rename the constant `SUCCESS_IMPORT_CODE` -> `SUCCESS_API_CODE`, which is more appropriate.
- Check api response codes when deleting a contact (since we're passing an array, some of them could fail)

Closes #283