### PR TITLE
Better way to reset search when switching groups

### DIFF
--- a/src/app/containers/ContactsContainer.js
+++ b/src/app/containers/ContactsContainer.js
@@ -74,6 +74,8 @@ const ContactsContainer = ({ location, history }) => {
         setCheckedContacts(Object.create(null));
         setCheckAll(false);
         setExpand(false);
+        // clean also the search
+        updateSearch('');
     }, [contactGroupID]);
 
     const contactEmailsMap = useMemo(() => {
@@ -291,7 +293,6 @@ const ContactsContainer = ({ location, history }) => {
                     totalContacts={contactsLength}
                     contactGroups={contactGroups}
                     userKeysList={userKeysList}
-                    onClearSearch={handleClearSearch}
                 />
                 <div className="main flex-item-fluid">
                     <ContactToolbar

--- a/src/app/content/PrivateSidebar.js
+++ b/src/app/content/PrivateSidebar.js
@@ -17,16 +17,13 @@ const PrivateSidebar = ({
     loadingUserKeys,
     totalContacts,
     contactGroups = [],
-    history,
-    onClearSearch
+    history
 }) => {
     const { hasPaidMail } = user;
     const { createModal } = useModals();
 
     const list = [
         {
-            type: 'button',
-            className: 'alignleft',
             icon: 'contacts',
             isActive(match, location) {
                 if (!match) {
@@ -37,10 +34,7 @@ const PrivateSidebar = ({
                 return !contactGroupID;
             },
             text: c('Link').t`Contacts`,
-            onClick() {
-                onClearSearch();
-                history.push(`/contacts`);
-            }
+            link: '/contacts'
         },
         !loadingUserKeys && {
             type: 'button',
@@ -78,8 +72,6 @@ const PrivateSidebar = ({
     if (hasPaidMail) {
         list.push(
             ...contactGroups.map(({ Name: text, Color: color, ID: contactGroupID }) => ({
-                type: 'button',
-                className: 'alignleft',
                 icon: 'contacts-groups',
                 isActive(_match, location) {
                     const params = new URLSearchParams(location.search);
@@ -87,10 +79,7 @@ const PrivateSidebar = ({
                 },
                 color,
                 text,
-                onClick() {
-                    onClearSearch();
-                    history.push(`/contacts?contactGroupID=${contactGroupID}`);
-                }
+                link: `/contacts?contactGroupID=${contactGroupID}`
             }))
         );
     }


### PR DESCRIPTION
Better https://github.com/ProtonMail/proton-contacts/pull/293

As @EpokK proposed, it's better to clear search when the group param change than when performing the navigation action.