### PR TITLE
Hotfix #299

### DIFF
--- a/src/app/content/PrivateSidebar.js
+++ b/src/app/content/PrivateSidebar.js
@@ -116,8 +116,7 @@ PrivateSidebar.propTypes = {
     onToggleExpand: PropTypes.func,
     userKeysList: PropTypes.array,
     loadingUserKeys: PropTypes.bool,
-    history: PropTypes.object.isRequired,
-    onClearSearch: PropTypes.func
+    history: PropTypes.object.isRequired
 };
 
 export default PrivateSidebar;


### PR DESCRIPTION
Remove unexistent `onClearSeach` prop from `PrivateSidebar.propTypes`