### PR TITLE
Fix some import bugs (mainly csv) plus better delete UX

### DIFF
--- a/src/app/components/ContactsList.js
+++ b/src/app/components/ContactsList.js
@@ -69,7 +69,7 @@ const ContactsList = ({
 
     useEffect(() => {
         const timeoutID = setTimeout(() => {
-            if (contactID) {
+            if (contactID && totalContacts) {
                 const index = contacts.findIndex(({ ID }) => contactID === ID);
                 listRef.current.scrollToRow(index);
             }

--- a/src/app/components/import/ImportingModalContent.js
+++ b/src/app/components/import/ImportingModalContent.js
@@ -13,12 +13,19 @@ import { extractVcards, parse as parseVcard } from '../../helpers/vcard';
 import { prepareContact } from '../../helpers/encrypt';
 import { splitContacts } from '../../helpers/import';
 import { combineProgress } from '../../helpers/progress';
-import { OVERWRITE, CATEGORIES, API_SAFE_INTERVAL, ADD_CONTACTS_MAX_SIZE } from '../../constants';
+import {
+    OVERWRITE,
+    CATEGORIES,
+    API_SAFE_INTERVAL,
+    ADD_CONTACTS_MAX_SIZE,
+    MAX_SIMULTANEOUS_CONTACTS_ENCRYPT
+} from '../../constants';
 import { API_CODES } from 'proton-shared/lib/constants';
 
 const { OVERWRITE_CONTACT } = OVERWRITE;
 const { IGNORE, INCLUDE } = CATEGORIES;
 const { SINGLE_SUCCESS } = API_CODES;
+const ONE_HOUR = 1000 * 60 * 60;
 
 const createParseErrorMessage = (index, message) =>
     c('Info on errors importing contacts').t`Contact ${index} from your list could not be parsed. ${message}`;
@@ -109,8 +116,8 @@ const ImportingModalContent = ({ isVcf, file = '', vcardContacts, privateKey, on
         const encryptContacts = async (contacts = [], { signal }) => {
             const publicKey = privateKey.toPublic();
 
-            // encrypt 5 contacts at a time to speed up the process without burning the user's machine
-            const contactBatches = chunk(contacts, 5);
+            // encrypt several contacts at a time to speed up the process without burning the user's machine
+            const contactBatches = chunk(contacts, MAX_SIMULTANEOUS_CONTACTS_ENCRYPT);
 
             const encryptedContacts = [];
             for (const batch of contactBatches) {
@@ -134,14 +141,14 @@ const ImportingModalContent = ({ isVcf, file = '', vcardContacts, privateKey, on
 
             const indexMap = contacts.map(({ index }) => index);
 
-            const INFINITE_TIME = 1000 * 60 * 60; // 1 hour
             const responses = (await apiWithAbort(
                 addContacts({
                     Contacts: contacts.map(({ contact }) => contact),
                     Overwrite: OVERWRITE_CONTACT,
                     Labels: labels,
-                    // we need to increase the standard timeout limit for this route since it seems a bit slow currently
-                    timeout: INFINITE_TIME
+                    // we need to increase the standard timeout limit for this route since it may be slow sometimes
+                    // 1 hour to wait for an API response is essentially infinite time
+                    timeout: ONE_HOUR
                 })
             )).Responses.map(({ Response }) => Response);
 

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -53,6 +53,8 @@ export const CATEGORIES = {
 // BACK-END DATA
 export const API_SAFE_INTERVAL = 100; // API request limit: 100 requests / 10 seconds, so 1 request every 100 ms is safe
 export const QUERY_EXPORT_MAX_PAGESIZE = 50; // in GET API route /contacts/export
-// Manual limit on number of imported contacts to be sent to the API,
-// so that the response does not take too long (there's a 30s limit)
-export const ADD_CONTACTS_MAX_SIZE = 200;
+// Manual limit on number of imported contacts to be sent to the API, so that the response does not take too long
+export const ADD_CONTACTS_MAX_SIZE = 100;
+
+// FRONT-END RESTRICTIONS
+export const MAX_SIMULTANEOUS_CONTACTS_ENCRYPT = 5;

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -55,4 +55,4 @@ export const API_SAFE_INTERVAL = 100; // API request limit: 100 requests / 10 se
 export const QUERY_EXPORT_MAX_PAGESIZE = 50; // in GET API route /contacts/export
 // Manual limit on number of imported contacts to be sent to the API,
 // so that the response does not take too long (there's a 30s limit)
-export const ADD_CONTACTS_MAX_SIZE = 100;
+export const ADD_CONTACTS_MAX_SIZE = 50;

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -55,4 +55,4 @@ export const API_SAFE_INTERVAL = 100; // API request limit: 100 requests / 10 se
 export const QUERY_EXPORT_MAX_PAGESIZE = 50; // in GET API route /contacts/export
 // Manual limit on number of imported contacts to be sent to the API,
 // so that the response does not take too long (there's a 30s limit)
-export const ADD_CONTACTS_MAX_SIZE = 50;
+export const ADD_CONTACTS_MAX_SIZE = 200;

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -55,4 +55,4 @@ export const API_SAFE_INTERVAL = 100; // API request limit: 100 requests / 10 se
 export const QUERY_EXPORT_MAX_PAGESIZE = 50; // in GET API route /contacts/export
 // Manual limit on number of imported contacts to be sent to the API,
 // so that the response does not take too long (there's a 30s limit)
-export const ADD_CONTACTS_MAX_SIZE = 500;
+export const ADD_CONTACTS_MAX_SIZE = 100;

--- a/src/app/containers/ContactsContainer.js
+++ b/src/app/containers/ContactsContainer.js
@@ -165,15 +165,23 @@ const ContactsContainer = ({ location, history }) => {
                 </ConfirmModal>
             );
         });
+        const clearChecked = () => {
+            setCheckedContacts(Object.create(null));
+            setCheckAll(false);
+        };
         if (checkAll && !contactGroupID) {
             await api(clearContacts());
+            history.push({ ...location, pathname: '/contacts' });
+            await call();
+            clearChecked();
             return createNotification({ text: c('Success').t`Contacts deleted` });
         }
         const apiResponse = await api(deleteContacts(activeIDs));
-        history.push({ ...location, pathname: '/contacts' });
+        if (contactID && checkedContacts[contactID]) {
+            history.push({ ...location, pathname: '/contacts' });
+        }
         await call();
-        setCheckedContacts(Object.create(null));
-        setCheckAll(false);
+        clearChecked();
         if (!allSucceded(apiResponse)) {
             return createNotification({ text: c('Error').t`Some contacts could not be deleted`, type: 'warning' });
         }
@@ -223,7 +231,7 @@ const ContactsContainer = ({ location, history }) => {
     const contactsLength = contacts ? contacts.length : 0;
     const noHeader = isNarrow && contactID ? '--noHeader' : '';
 
-    const contactComponent = contactID && contactsLength && !hasChecked && (
+    const contactComponent = contactID && !!contactsLength && !hasChecked && (
         <Contact
             contactID={contactID}
             contactEmails={contactEmailsMap[contactID]}

--- a/src/app/helpers/csv.js
+++ b/src/app/helpers/csv.js
@@ -80,31 +80,6 @@ export const readCsv = async (file) => {
 };
 
 /**
- * For a list of headers and csv contacts extracted from a csv,
- * check if a given header index has the empty value for all contacts
- * @param {Number} index
- * @param {Array<Array<String>>} contacts
- *
- * @return {Boolean}
- */
-const isEmptyHeaderIndex = (index, contacts) => !contacts.some((values) => values[index] !== '');
-
-/**
- * Extract (only) non-empty csv properties and contacts values from a read csv file
- * @param {Array<String>} headers
- * @param {Array<Array<String>>} contacts
- *
- * @return {Object}         { headers: Array<String>, contacts: Array<Array<String>> }
- */
-const getNonEmptyCsvData = ({ headers, contacts }) => {
-    const indicesToKeep = headers.map((_header, i) => !isEmptyHeaderIndex(i, contacts));
-    return {
-        headers: headers.filter((_header, i) => indicesToKeep[i]),
-        contacts: contacts.map((values) => values.filter((_value, j) => indicesToKeep[j]))
-    };
-};
-
-/**
  * Transform csv properties and csv contacts into pre-vCard contacts.
  * @param {Object} csvData
  * @param {Array<String>} csvData.headers           Array of csv properties
@@ -119,9 +94,7 @@ const parse = ({ headers = [], contacts = [] }) => {
     if (!contacts.length) {
         return [];
     }
-    const { headers: standardHeaders, contacts: standardContacts } = standarize(
-        getNonEmptyCsvData({ headers, contacts })
-    );
+    const { headers: standardHeaders, contacts: standardContacts } = standarize({ headers, contacts });
 
     const translator = standardHeaders.map(toPreVcard);
 

--- a/src/app/helpers/csvFormat.js
+++ b/src/app/helpers/csvFormat.js
@@ -69,10 +69,14 @@ export const standarize = ({ headers, contacts }) => {
     if (!contacts.length) {
         return { headers, contacts };
     }
+
+    // do a first simple formatting of headers
+    const formattedHeaders = headers.map((header) => header.replace('_', ' '));
+
     // change name of certain headers into outlook equivalents
     // remove headers we are not interested in
     // merge headers 'xxx - type' and 'xxx - value' into one header
-    const { beRemoved, beChanged } = headers.reduce(
+    const { beRemoved, beChanged } = formattedHeaders.reduce(
         (acc, header, i) => {
             const headerLowerCase = header.toLowerCase();
             const { beRemoved, beChanged } = acc;
@@ -84,6 +88,15 @@ export const standarize = ({ headers, contacts }) => {
             ) {
                 beRemoved[i] = true;
                 return acc;
+            }
+            if (header === 'address') {
+                beChanged[i] = 'street';
+            }
+            if (header === 'zip') {
+                beChanged[i] = 'postal code';
+            }
+            if (header === 'county') {
+                beChanged[i] = 'state';
             }
             /*
                 consecutive headers for address n property are (n is an integer)
@@ -158,7 +171,7 @@ export const standarize = ({ headers, contacts }) => {
         { beRemoved: Object.create(null), beChanged: Object.create(null) }
     );
 
-    const standardHeaders = headers
+    const standardHeaders = formattedHeaders
         .map((header, index) => (beChanged[index] ? beChanged[index] : header))
         .filter((_header, index) => !beRemoved[index]);
 
@@ -282,8 +295,8 @@ export const toPreVcard = (header) => {
         const [, pref] = property.match(/^department\s?(\d*)/);
         return (value) => templates['org']({ pref, header, value, index: 1 });
     }
-    if (/^(\w+)?\s?e-mail\s?(\d*)/.test(property)) {
-        const [, type, pref] = property.match(/^(\w+)?\s?e-mail\s?(\d*)/);
+    if (/^(\w+)?\s?e-?mail\s?(\d*)/.test(property)) {
+        const [, type, pref] = property.match(/^(\w+)?\s?e-?mail\s?(\d*)/);
         return (value) => templates['email']({ pref, header, value, type: type ? toVcardType(type) : '' });
     }
     if (/^(\w+\s*\w+)?\s?phone\s?(\d*)$/.test(property)) {
@@ -302,32 +315,32 @@ export const toPreVcard = (header) => {
         const [, pref] = property.match(/^callback|telex\s?(\d*)$/);
         return (value) => templates['tel']({ pref, header, value, type: 'other' });
     }
-    if (/^(\w+) po box\s?(\d*)$/.test(property)) {
-        const [, type, pref] = property.match(/^(\w+) po box\s?(\d*)$/);
+    if (/^(\w*)\s?po box\s?(\d*)$/.test(property)) {
+        const [, type, pref] = property.match(/^(\w*)\s?po box\s?(\d*)$/);
         return (value) => templates['adr']({ pref, header, type: toVcardType(type), value, index: 0 });
     }
-    if (/^(\w+) extended address\s?(\d*)$/.test(property)) {
-        const [, type, pref] = property.match(/^(\w+) extended address\s?(\d*)$/);
+    if (/^(\w*)\s?extended address\s?(\d*)$/.test(property)) {
+        const [, type, pref] = property.match(/^(\w*)\s?extended address\s?(\d*)$/);
         return (value) => templates['adr']({ pref, header, type: toVcardType(type), value, index: 1 });
     }
-    if (/^(\w+) street\s?(\d*)$/.test(property)) {
-        const [, type, pref] = property.match(/^(\w+) street\s?(\d*)$/);
+    if (/^(\w*)\s?street\s?(\d*)$/.test(property)) {
+        const [, type, pref] = property.match(/^(\w*)\s?street\s?(\d*)$/);
         return (value) => templates['adr']({ pref, header, type: toVcardType(type), value, index: 2 });
     }
-    if (/^(\w+) city\s?(\d*)$/.test(property)) {
-        const [, type, pref] = property.match(/^(\w+) city\s?(\d*)$/);
+    if (/^(\w*)\s?city\s?(\d*)$/.test(property)) {
+        const [, type, pref] = property.match(/^(\w*)\s?city\s?(\d*)$/);
         return (value) => templates['adr']({ pref, header, type: toVcardType(type), value, index: 3 });
     }
-    if (/^(\w+) state\s?(\d*)$/.test(property)) {
-        const [, type, pref] = property.match(/^(\w+) state\s?(\d*)$/);
+    if (/^(\w*)\s?state\s?(\d*)$/.test(property)) {
+        const [, type, pref] = property.match(/^(\w*)\s?state\s?(\d*)$/);
         return (value) => templates['adr']({ pref, header, type: toVcardType(type), value, index: 4 });
     }
-    if (/^(\w+) postal code\s?(\d*)$/.test(property)) {
-        const [, type, pref] = property.match(/^(\w+) postal code\s?(\d*)$/);
+    if (/^(\w*)\s?postal code\s?(\d*)$/.test(property)) {
+        const [, type, pref] = property.match(/^(\w*)\s?postal code\s?(\d*)$/);
         return (value) => templates['adr']({ pref, header, type: toVcardType(type), value, index: 5 });
     }
-    if (/^(\w+) country\/region\s?(\d*)$/.test(property)) {
-        const [, type, pref] = property.match(/^(\w+) country\/region\s?(\d*)$/);
+    if (/^(\w*)\s?country\/region\s?(\d*)$/.test(property)) {
+        const [, type, pref] = property.match(/^(\w*)\s?country\/region\s?(\d*)$/);
         return (value) => templates['adr']({ pref, header, type: toVcardType(type), value, index: 6 });
     }
     if (property === 'nickname') {
@@ -413,7 +426,7 @@ export const toPreVcard = (header) => {
             field: 'anniversary'
         });
     }
-    if (property === 'personal web page' || property.includes('website')) {
+    if (property.includes('web')) {
         return (value) => ({
             header,
             value,

--- a/src/app/helpers/csvFormat.js
+++ b/src/app/helpers/csvFormat.js
@@ -27,21 +27,6 @@ const beIgnoredCsvProperties = [
  */
 const isEmptyHeaderIndex = (index, contacts) => !contacts.some((values) => values[index] !== '');
 
-// /**
-//  * Extract (only) non-empty csv properties and contacts values from a read csv file
-//  * @param {Array<String>} headers
-//  * @param {Array<Array<String>>} contacts
-//  *
-//  * @return {Object}         { headers: Array<String>, contacts: Array<Array<String>> }
-//  */
-// const getNonEmptyCsvData = ({ headers, contacts }) => {
-//     const indicesToKeep = headers.map((_header, i) => !isEmptyHeaderIndex(i, contacts));
-//     return {
-//         headers: headers.filter((_header, i) => indicesToKeep[i]),
-//         contacts: contacts.map((values) => values.filter((_value, j) => indicesToKeep[j]))
-//     };
-// };
-
 /**
  * Standarize a custom vcard type coming from a csv property
  * @param {String} csvType


### PR DESCRIPTION
Bugs on import:
- Capturing csv's using underscore now (first_name -> first name)
- Better capture of several csv properties (mainly addresses, but also photo and logo, ignored before)
- Remove front-end timeout of 30s for the route submitting imported contacts. It seems the response is very slow these days from the back-end. I also reduced the import batch size.
- Improve speed of import by encrypting 5 contacts at a time.

Bugs on delete UX:
- After "delete all", we were not navigating to `/contacts` and we were leaving the checkbox for "check all" ticked.
- Only navigate away from current contact if it's deleted.
- `ContactsPlaceholder` was equal to `0` instead of `null` in some instances.

Fixes #292
Closes #317
Needs https://github.com/ProtonMail/proton-shared/pull/68 and https://github.com/ProtonMail/proton-shared/pull/69