### PR TITLE
fix crash when creating new contact group

### DIFF
--- a/src/app/components/ContactRow.js
+++ b/src/app/components/ContactRow.js
@@ -37,6 +37,9 @@ const ContactRow = ({ style, contactID, hasPaidMail, contactGroupsMap, contact, 
                         {hasPaidMail && LabelIDs.length ? (
                             <div>
                                 {LabelIDs.map((labelID) => {
+                                    if (!contactGroupsMap[labelID]) {
+                                        return null;
+                                    }
                                     const { Color, Name } = contactGroupsMap[labelID];
                                     return (
                                         <ContactGroupIcon

--- a/src/app/components/ContactViewProperties.js
+++ b/src/app/components/ContactViewProperties.js
@@ -50,7 +50,8 @@ const ContactViewProperties = ({
             </h3>
             {properties.map((property, index) => {
                 const contactEmail = contactEmails && contactEmails[index];
-                const contactGroups = contactEmail && contactEmail.LabelIDs.map((ID) => contactGroupsMap[ID]);
+                const contactGroups =
+                    contactEmail && contactEmail.LabelIDs.map((ID) => contactGroupsMap[ID]).filter(Boolean);
 
                 return (
                     // here we are hiddenly using the fact that the emails in

--- a/src/app/content/PrivateHeader.js
+++ b/src/app/content/PrivateHeader.js
@@ -88,7 +88,7 @@ PrivateHeader.propTypes = {
     onSearch: PropTypes.func,
     inSettings: PropTypes.bool,
     isNarrow: PropTypes.bool,
-    history: PropTypes.object.isRequired
+    history: PropTypes.object
 };
 
 export default PrivateHeader;


### PR DESCRIPTION
As described in #304, when creating a new group from the contact view and adding the contact in the view to the list, the app crashes. The reason is that the new email labels (for the recently created group) are created before the list of contact groups is updated. This creates a mismatch that the app is unable to handle. It's enough to add a couple of lines to take care of this mismatch.

I also removed a `isRequired` property from a prop because it's not always required.

Fixes #304