### PR TITLE
Use date-fns

### DIFF
--- a/src/app/components/ContactFieldProperty.js
+++ b/src/app/components/ContactFieldProperty.js
@@ -32,19 +32,10 @@ const ContactFieldProperty = ({ field, value, uid, onChange, ...rest }) => {
     }
 
     if (field === 'bday' || field === 'anniversary') {
-        const m = moment(value);
+        const m = moment(value || Date.now());
         if (value === '' || m.isValid()) {
             const handleSelectDate = (date) => onChange({ value: date.toISOString(), uid });
-            return (
-                <DateInput
-                    setDefaultDate
-                    placeholder={labels[field]}
-                    defaultDate={m.toDate()}
-                    onSelect={handleSelectDate}
-                    format={moment.localeData().longDateFormat('L')}
-                    {...rest}
-                />
-            );
+            return <DateInput placeholder={labels[field]} value={m.toDate()} onChange={handleSelectDate} {...rest} />;
         }
     }
 

--- a/src/app/components/ContactFieldProperty.js
+++ b/src/app/components/ContactFieldProperty.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
 import { useModals, Input, TextArea, EmailInput, DateInput, TelInput } from 'react-components';
+import { parseISO, toDate, isValid } from 'date-fns';
 import { getAllFieldLabels } from '../helpers/fields';
 
 import ContactImageField from './ContactImageField';
@@ -32,10 +32,10 @@ const ContactFieldProperty = ({ field, value, uid, onChange, ...rest }) => {
     }
 
     if (field === 'bday' || field === 'anniversary') {
-        const m = moment(value || Date.now());
-        if (value === '' || m.isValid()) {
+        const date = value === '' ? toDate(Date.now()) : parseISO(value);
+        if (isValid(date)) {
             const handleSelectDate = (date) => onChange({ value: date.toISOString(), uid });
-            return <DateInput placeholder={labels[field]} value={m.toDate()} onChange={handleSelectDate} {...rest} />;
+            return <DateInput placeholder={labels[field]} value={date} onChange={handleSelectDate} {...rest} />;
         }
     }
 

--- a/src/app/components/ContactFieldProperty.js
+++ b/src/app/components/ContactFieldProperty.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useModals, Input, TextArea, EmailInput, DateInput, TelInput } from 'react-components';
-import { parseISO, toDate, isValid } from 'date-fns';
+import { parseISO, isValid } from 'date-fns';
 import { getAllFieldLabels } from '../helpers/fields';
 
 import ContactImageField from './ContactImageField';
@@ -32,7 +32,7 @@ const ContactFieldProperty = ({ field, value, uid, onChange, ...rest }) => {
     }
 
     if (field === 'bday' || field === 'anniversary') {
-        const date = value === '' ? toDate(Date.now()) : parseISO(value);
+        const date = value === '' ? new Date() : parseISO(value);
         if (isValid(date)) {
             const handleSelectDate = (date) => onChange({ value: date.toISOString(), uid });
             return <DateInput placeholder={labels[field]} value={date} onChange={handleSelectDate} {...rest} />;

--- a/src/app/components/ContactKeysTable.js
+++ b/src/app/components/ContactKeysTable.js
@@ -2,8 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { move } from 'proton-shared/lib/helpers/array';
 import PropTypes from 'prop-types';
 import { c } from 'ttag';
+import { toDate, isValid, format } from 'date-fns';
 import { serverTime } from 'pmcrypto/lib/serverTime';
-import moment from 'moment';
 import downloadFile from 'proton-shared/lib/helpers/downloadFile';
 import { describe } from 'proton-shared/lib/keys/keysAlgorithm';
 import { Table, TableHeader, TableBody, TableRow, Badge, DropdownActions } from 'react-components';
@@ -68,7 +68,7 @@ const ContactKeysTable = ({ model, setModel }) => {
                         { fingerprint, algo, creationTime, isPrimary, publicKey, isExpired, isRevoked, isTrusted },
                         index
                     ) => {
-                        const creation = moment(creationTime);
+                        const creation = toDate(creationTime);
                         const list = [
                             {
                                 text: c('Action').t`Download`,
@@ -133,7 +133,7 @@ const ContactKeysTable = ({ model, setModel }) => {
                                 />
                                 <span className="flex-item-fluid ellipsis">{fingerprint}</span>
                             </div>,
-                            creation.isValid() ? creation.format('ll') : '-',
+                            isValid(creation) ? format(creation, 'PP') : '-',
                             algo,
                             <React.Fragment key={fingerprint}>
                                 {isPrimary ? <Badge>{c('Key badge').t`Primary`}</Badge> : null}

--- a/src/app/components/ContactKeysTable.js
+++ b/src/app/components/ContactKeysTable.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Table, TableHeader, TableBody, TableRow, Badge, DropdownActions } from 'react-components';
 import PropTypes from 'prop-types';
 import { c } from 'ttag';
-import { toDate, isValid, format } from 'date-fns';
+import { isValid, format } from 'date-fns';
 
 import { move } from 'proton-shared/lib/helpers/array';
 import { dateLocale } from 'proton-shared/lib/i18n';
@@ -70,7 +70,7 @@ const ContactKeysTable = ({ model, setModel }) => {
                         { fingerprint, algo, creationTime, isPrimary, publicKey, isExpired, isRevoked, isTrusted },
                         index
                     ) => {
-                        const creation = toDate(creationTime);
+                        const creation = new Date(creationTime);
                         const list = [
                             {
                                 text: c('Action').t`Download`,

--- a/src/app/components/ContactKeysTable.js
+++ b/src/app/components/ContactKeysTable.js
@@ -1,12 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import { move } from 'proton-shared/lib/helpers/array';
+import { Table, TableHeader, TableBody, TableRow, Badge, DropdownActions } from 'react-components';
 import PropTypes from 'prop-types';
 import { c } from 'ttag';
 import { toDate, isValid, format } from 'date-fns';
+
+import { move } from 'proton-shared/lib/helpers/array';
+import { dateLocale } from 'proton-shared/lib/i18n';
 import { serverTime } from 'pmcrypto/lib/serverTime';
 import downloadFile from 'proton-shared/lib/helpers/downloadFile';
 import { describe } from 'proton-shared/lib/keys/keysAlgorithm';
-import { Table, TableHeader, TableBody, TableRow, Badge, DropdownActions } from 'react-components';
 
 import KeyWarningIcon from './KeyWarningIcon';
 
@@ -133,7 +135,7 @@ const ContactKeysTable = ({ model, setModel }) => {
                                 />
                                 <span className="flex-item-fluid ellipsis">{fingerprint}</span>
                             </div>,
-                            isValid(creation) ? format(creation, 'PP') : '-',
+                            isValid(creation) ? format(creation, 'PP', { locale: dateLocale }) : '-',
                             algo,
                             <React.Fragment key={fingerprint}>
                                 {isPrimary ? <Badge>{c('Key badge').t`Primary`}</Badge> : null}

--- a/src/app/components/ContactViewProperty.js
+++ b/src/app/components/ContactViewProperty.js
@@ -15,7 +15,9 @@ import {
 import { c } from 'ttag';
 import { parseISO, toDate, isValid, format } from 'date-fns';
 
+import { dateLocale } from 'proton-shared/lib/i18n';
 import { clearType, getType, formatAdr } from '../helpers/property';
+
 import ContactGroupIcon from './ContactGroupIcon';
 import ContactGroupDropdown from './ContactGroupDropdown';
 import ContactLabelProperty from './ContactLabelProperty';
@@ -63,7 +65,7 @@ const ContactViewProperty = ({
         if (['bday', 'anniversary'].includes(field)) {
             const [date] = [parseISO(value), toDate(value)].filter(isValid);
             if (date) {
-                return format(date, 'PP');
+                return format(date, 'PP', { locale: dateLocale });
             }
             return value;
         }

--- a/src/app/components/ContactViewProperty.js
+++ b/src/app/components/ContactViewProperty.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import moment from 'moment';
 import PropTypes from 'prop-types';
 import {
     Row,
@@ -14,6 +13,7 @@ import {
     RemoteImage
 } from 'react-components';
 import { c } from 'ttag';
+import { parseISO, toDate, isValid, format } from 'date-fns';
 
 import { clearType, getType, formatAdr } from '../helpers/property';
 import ContactGroupIcon from './ContactGroupIcon';
@@ -61,9 +61,9 @@ const ContactViewProperty = ({
             return <a href={`tel:${value}`}>{value}</a>;
         }
         if (['bday', 'anniversary'].includes(field)) {
-            const date = moment(value);
-            if (date.isValid()) {
-                return date.format('LL');
+            const [date] = [parseISO(value), toDate(value)].filter(isValid);
+            if (date) {
+                return format(date, 'PP');
             }
             return value;
         }

--- a/src/app/components/ContactViewProperty.js
+++ b/src/app/components/ContactViewProperty.js
@@ -13,7 +13,7 @@ import {
     RemoteImage
 } from 'react-components';
 import { c } from 'ttag';
-import { parseISO, toDate, isValid, format } from 'date-fns';
+import { parseISO, isValid, format } from 'date-fns';
 
 import { dateLocale } from 'proton-shared/lib/i18n';
 import { clearType, getType, formatAdr } from '../helpers/property';
@@ -63,7 +63,7 @@ const ContactViewProperty = ({
             return <a href={`tel:${value}`}>{value}</a>;
         }
         if (['bday', 'anniversary'].includes(field)) {
-            const [date] = [parseISO(value), toDate(value)].filter(isValid);
+            const [date] = [parseISO(value), new Date(value)].filter(isValid);
             if (date) {
                 return format(date, 'PP', { locale: dateLocale });
             }

--- a/src/app/components/ExportModal.js
+++ b/src/app/components/ExportModal.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { c } from 'ttag';
-import moment from 'moment';
+import { format } from 'date-fns';
 import { useContacts, useApi, FormModal, ResetButton, PrimaryButton, Alert } from 'react-components';
 import { queryContactExport } from 'proton-shared/lib/api/contacts';
 import downloadFile from 'proton-shared/lib/helpers/downloadFile';
@@ -47,7 +47,7 @@ const ExportModal = ({ contactGroupID: LabelID, userKeysList, onSave = noop, ...
     const handleSave = (vcards) => {
         const allVcards = vcards.join('\n');
         const blob = new Blob([allVcards], { type: 'data:text/plain;charset=utf-8;' });
-        downloadFile(blob, `${DOWNLOAD_FILENAME}-${moment().format('YYYY-MM-DD')}.vcf`);
+        downloadFile(blob, `${DOWNLOAD_FILENAME}-${format(Date.now(), 'yyyy-MM-dd')}.vcf`);
         onSave();
         rest.onClose();
     };


### PR DESCRIPTION
The crash described in #331 was happening because we were using a deprecated version of the DateInput component in `react-components`, which has been recently changed as part of the migration to the `date-fns` library.

There were a few places in contacts where we were using `moment`. This PR migrates those uses to `date-fns`

Closes #311 