### PR TITLE
Prevent phantom requests when clicking on contacts with no image

### DIFF
--- a/src/app/components/ContactImageSummary.js
+++ b/src/app/components/ContactImageSummary.js
@@ -16,6 +16,9 @@ const ContactImageSummary = ({ photo, name }) => {
     const loading = loadingMailSettings && loadingResize;
 
     useEffect(() => {
+        if (!photo) {
+            return;
+        }
         const resize = async () => {
             const { width, height } = await toImage(photo);
             setImage((image) => ({ ...image, width, height }));

--- a/src/app/components/ContactImageSummary.js
+++ b/src/app/components/ContactImageSummary.js
@@ -5,6 +5,7 @@ import { useMailSettings, useLoading, Loader, Button } from 'react-components';
 import { getInitial } from 'proton-shared/lib/helpers/string';
 import { isURL } from 'proton-shared/lib/helpers/validators';
 import { resizeImage, toImage } from 'proton-shared/lib/helpers/image';
+import { noop } from 'proton-shared/lib/helpers/function';
 import { SHOW_IMAGES } from 'proton-shared/lib/constants';
 import { CONTACT_IMG_SIZE } from '../constants';
 
@@ -14,9 +15,10 @@ const ContactImageSummary = ({ photo, name }) => {
     const [{ ShowImages }, loadingMailSettings] = useMailSettings();
     const [loadingResize, withLoadingResize] = useLoading();
     const loading = loadingMailSettings && loadingResize;
+    const showPhoto = ShowImages & SHOW_IMAGES.REMOTE || showAnyways;
 
     useEffect(() => {
-        if (!photo) {
+        if (!photo || !showPhoto) {
             return;
         }
         const resize = async () => {
@@ -34,8 +36,8 @@ const ContactImageSummary = ({ photo, name }) => {
             });
             setImage((image) => ({ ...image, src: resized }));
         };
-        withLoadingResize(resize());
-    }, [photo]);
+        withLoadingResize(resize().catch(noop));
+    }, [photo, showPhoto]);
 
     if (!photo) {
         return (
@@ -49,7 +51,7 @@ const ContactImageSummary = ({ photo, name }) => {
 
     const handleClick = () => setShowAnyways(true);
 
-    if (ShowImages & SHOW_IMAGES.REMOTE || showAnyways) {
+    if (showPhoto) {
         if (loading) {
             return <Loader />;
         }


### PR DESCRIPTION
When clicking on a contact with no image, there was a request to `localhost/undefined`. Somehow this was generated by the helper `toImage` when passed an `undefined` argument, which was happening in the `ContactImageSummary` component. This PR removes the call to `toImage(undefined)`