### PR TITLE
Fix bad-looking FN row in contact Modal

### DIFF
--- a/src/app/components/ContactModalLabel.js
+++ b/src/app/components/ContactModalLabel.js
@@ -17,7 +17,7 @@ const ContactModalLabel = ({ field, uid, type, onChange }) => {
 
     if (otherInformationFields.map(({ value: f }) => f).includes(field)) {
         return (
-            <Label className="pt0">
+            <Label className="pt0 mr1">
                 <Select value={field} options={otherInformationFields} onChange={handleChangeField} />
             </Label>
         );
@@ -28,7 +28,7 @@ const ContactModalLabel = ({ field, uid, type, onChange }) => {
     }
 
     return (
-        <Label className="pt0">
+        <Label className="pt0 mr1">
             <Select value={type} options={types[field]} onChange={handleChangeType} />
         </Label>
     );

--- a/src/app/components/ContactModalProperties.js
+++ b/src/app/components/ContactModalProperties.js
@@ -76,7 +76,7 @@ const ContactModalProperties = ({ properties: allProperties, field, onChange, on
                     </div>
                 </OrderableContainer>
             ) : (
-                rows
+                <div>{rows}</div>
             )}
             {canAdd && (
                 <div className="flex flex-nowrap flex-item-noshrink">

--- a/src/app/components/ContactModalProperties.js
+++ b/src/app/components/ContactModalProperties.js
@@ -83,7 +83,7 @@ const ContactModalProperties = ({ properties: allProperties, field, onChange, on
                     <div className="mr0-5 flex flex-items-center flex-item-noshrink">
                         <Icon name="text-justify nonvisible" />
                     </div>
-                    <div className="flex flex-nowrap onmobile-flex-column w95">
+                    <div className="flex flex-nowrap w95">
                         <PrimaryButton className="mb1" onClick={onAdd}>{c('Action').t`Add`}</PrimaryButton>
                     </div>
                 </div>

--- a/src/app/components/ContactModalRow.js
+++ b/src/app/components/ContactModalRow.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { OrderableHandle, Icon, Field, DropdownActions, useModals } from 'react-components';
+import { OrderableHandle, Icon, DropdownActions, useModals } from 'react-components';
 import { c } from 'ttag';
 
 import { clearType, getType } from '../helpers/property';
@@ -54,18 +54,18 @@ const ContactModalRow = ({ property, onChange, onRemove, isOrderable = false }) 
                 </div>
             )}
             <div className="flex flex-nowrap flex-items-center onmobile-flex-column w95">
-                <span className="w30 flex flex-nowrap mr1 mb1">
+                <span className="w30 flex flex-nowrap mb1">
                     <ContactModalLabel field={field} type={type} uid={property.uid} onChange={onChange} />
                 </span>
-                <span className="w50 mr1 mb1">
-                    <Field>
+                <span className="w50 mb1">
+                    <div className="mr1">
                         <ContactFieldProperty
                             field={field}
                             value={property.value}
                             uid={property.uid}
                             onChange={onChange}
                         />
-                    </Field>
+                    </div>
                 </span>
                 <span className="w20 mb1">
                     {list.length > 0 && (

--- a/src/app/components/ContactModalRow.js
+++ b/src/app/components/ContactModalRow.js
@@ -53,7 +53,7 @@ const ContactModalRow = ({ property, onChange, onRemove, isOrderable = false }) 
                     <Icon name="text-justify nonvisible" />
                 </div>
             )}
-            <div className="flex flex-nowrap onmobile-flex-column w95">
+            <div className="flex flex-nowrap flex-items-center onmobile-flex-column w95">
                 <span className="w30 flex flex-nowrap mr1 mb1">
                     <ContactModalLabel field={field} type={type} uid={property.uid} onChange={onChange} />
                 </span>


### PR DESCRIPTION
Recent changes dislocated the name field in the contact modal. This PR fixes #327