### PR TITLE
correct parsing of Papa.parse which goes south with certain csv files

### DIFF
--- a/src/app/helpers/csv.js
+++ b/src/app/helpers/csv.js
@@ -76,7 +76,13 @@ export const readCsv = async (file) => {
         throw new Error('Error when reading csv file');
     }
 
-    return { headers, contacts };
+    // we have to manually correct Papa.parse which can return headers and contacts of different length
+    const headersLength = headers.length;
+    const filteredContacts = contacts
+        .map((contact) => contact.slice(0, headersLength))
+        .filter((contact) => contact.length === headersLength);
+
+    return { headers, contacts: filteredContacts };
 };
 
 /**

--- a/src/app/helpers/csvFormat.js
+++ b/src/app/helpers/csvFormat.js
@@ -1,4 +1,4 @@
-import { capitalize } from 'proton-shared/lib/helpers/string';
+import { capitalize, normalize } from 'proton-shared/lib/helpers/string';
 
 // See './csv.js' for the definition of pre-vCard and pre-vCards contact
 
@@ -275,7 +275,7 @@ const templates = {
  * @return {Function}
  */
 export const toPreVcard = ({ original, standard }) => {
-    const property = standard.toLowerCase().trim();
+    const property = normalize(standard);
     const header = original;
     if (['title', 'name prefix'].includes(property)) {
         return (value) => [templates['fn']({ header, value, index: 0 }), templates['n']({ header, value, index: 3 })];

--- a/src/app/helpers/csvFormat.js
+++ b/src/app/helpers/csvFormat.js
@@ -275,7 +275,7 @@ const templates = {
  * @return {Function}
  */
 export const toPreVcard = ({ original, standard }) => {
-    const property = standard.toLowerCase();
+    const property = standard.toLowerCase().trim();
     const header = original;
     if (['title', 'name prefix'].includes(property)) {
         return (value) => [templates['fn']({ header, value, index: 0 }), templates['n']({ header, value, index: 3 })];


### PR DESCRIPTION
The external library (Papa parse) we're using for parsing CSV files is not doing its job properly on csv files with empty headers (at least when they're in the last column). I added an extra layer of parsing in the code so that empty headers are skipped (I couldn't find how to do it with Papa parse).

Closes #292