### PR TITLE
Improve image loading

### DIFF
--- a/src/app/components/ContactImageSummary.js
+++ b/src/app/components/ContactImageSummary.js
@@ -13,8 +13,8 @@ const ContactImageSummary = ({ photo, name }) => {
     const [showAnyways, setShowAnyways] = useState(!isURL(photo));
     const [image, setImage] = useState({ src: photo });
     const [{ ShowImages }, loadingMailSettings] = useMailSettings();
-    const [loadingResize, withLoadingResize] = useLoading();
-    const loading = loadingMailSettings && loadingResize;
+    const [loadingResize, withLoadingResize] = useLoading(true);
+    const loading = loadingMailSettings || loadingResize;
     const showPhoto = ShowImages & SHOW_IMAGES.REMOTE || showAnyways;
 
     useEffect(() => {
@@ -22,11 +22,10 @@ const ContactImageSummary = ({ photo, name }) => {
             return;
         }
         const resize = async () => {
-            const { width, height } = await toImage(photo);
-            setImage((image) => ({ ...image, width, height }));
+            const { src, width, height } = await toImage(photo);
 
             if (width <= CONTACT_IMG_SIZE && height <= CONTACT_IMG_SIZE) {
-                return setImage((image) => ({ ...image, isSmall: true }));
+                return setImage({ src, width, height, isSmall: true });
             }
             const resized = await resizeImage({
                 original: photo,
@@ -34,7 +33,7 @@ const ContactImageSummary = ({ photo, name }) => {
                 maxHeight: CONTACT_IMG_SIZE,
                 bigResize: true
             });
-            setImage((image) => ({ ...image, src: resized }));
+            setImage({ src: resized });
         };
         withLoadingResize(resize().catch(noop));
     }, [photo, showPhoto]);


### PR DESCRIPTION
After a recent change which make images load only after clicking "Load photo", the image loading was slightly broken:
After editing a contact, if the image was small, it wouldn't be updated after closing the modal.
When loading the image, it would flash very quickly the image not rounded, which is ugly if noticed. A loader is being displayed now instead of that quick intermediate step