### PR TITLE
Implement WKD

### DIFF
--- a/src/app/components/ContactEmailSettingsModal.js
+++ b/src/app/components/ContactEmailSettingsModal.js
@@ -63,7 +63,7 @@ const ContactEmailSettingsModal = ({ userKeysList, contactID, properties, emailP
      * Initialize the model for the modal
      * @returns {Promise}
      */
-    const prepare = async () => {
+    const prepare = async (api) => {
         // prepare keys stored in the vCard
         const { pinnedKeys, mimeType, encrypt, scheme } = await getKeysFromProperties(properties, emailGroup);
         const trustedFingerprints = new Set();
@@ -158,10 +158,15 @@ const ContactEmailSettingsModal = ({ userKeysList, contactID, properties, emailP
     };
 
     useEffect(() => {
+        const abortController = new AbortController();
+        const apiWithAbort = (config) => api({ ...config, signal: abortController.signal });
         // prepare the model once mail settings have been loaded
         if (!loadingMailSettings) {
-            withLoading(prepare());
+            withLoading(prepare(apiWithAbort));
         }
+        return () => {
+            abortController.abort();
+        };
     }, [loadingMailSettings]);
 
     useEffect(() => {
@@ -268,7 +273,7 @@ const ContactEmailSettingsModal = ({ userKeysList, contactID, properties, emailP
                     {showPgpSettings ? <ContactPgpSettings model={model} setModel={setModel} /> : null}
                 </InnerModal>
                 <FooterModal>
-                    <ResetButton disabled={isLoading}>{c('Action').t`Cancel`}</ResetButton>
+                    <ResetButton>{c('Action').t`Cancel`}</ResetButton>
                     <PrimaryButton loading={isLoading} disabled={!showPgpSettings} type="submit">
                         {c('Action').t`Save`}
                     </PrimaryButton>

--- a/src/app/components/ContactEmailSettingsModal.js
+++ b/src/app/components/ContactEmailSettingsModal.js
@@ -31,7 +31,7 @@ import { addContacts } from 'proton-shared/lib/api/contacts';
 import { getPublicKeysEmailHelper } from 'proton-shared/lib/api/helpers/publicKeys';
 import { uniqueBy } from 'proton-shared/lib/helpers/array';
 
-import { VCARD_KEY_FIELDS, PGP_INLINE, PGP_MIME, PGP_SIGN, CATEGORIES } from '../constants';
+import { VCARD_KEY_FIELDS, PGP_INLINE, PGP_MIME, CATEGORIES } from '../constants';
 import { PACKAGE_TYPE, MIME_TYPES, KEY_FLAGS } from 'proton-shared/lib/constants';
 
 import ContactMIMETypeSelect from './ContactMIMETypeSelect';
@@ -65,7 +65,11 @@ const ContactEmailSettingsModal = ({ userKeysList, contactID, properties, emailP
      */
     const prepare = async (api) => {
         // prepare keys stored in the vCard
-        const { pinnedKeys, mimeType, encrypt, scheme } = await getKeysFromProperties(properties, emailGroup);
+        const { pinnedKeys, mimeType, encrypt, scheme, sign } = await getKeysFromProperties(
+            properties,
+            emailGroup,
+            Sign
+        );
         const trustedFingerprints = new Set();
         const expiredFingerprints = new Set();
         const revokedFingerprints = new Set();
@@ -102,7 +106,7 @@ const ContactEmailSettingsModal = ({ userKeysList, contactID, properties, emailP
             mimeType,
             encrypt,
             scheme,
-            sign: Sign === PGP_SIGN,
+            sign,
             email: Email,
             keys: { api: orderedApiKeys, pinned: pinnedKeys },
             trustedFingerprints,

--- a/src/app/components/ContactEmailSettingsModal.js
+++ b/src/app/components/ContactEmailSettingsModal.js
@@ -130,7 +130,17 @@ const ContactEmailSettingsModal = ({ userKeysList, contactID, properties, emailP
         const config = await getPublicKeysEmailHelper(api, Email);
         const internalUser = isInternalUser(config);
         const externalUser = !internalUser;
-        const apiKeys = config.publicKeys;
+        const { apiKeys, apiKeysFlags } = config.Keys.reduce(
+            (acc, { Flags }, index) => {
+                const publicKey = config.publicKeys[index];
+                if (publicKey) {
+                    acc.apiKeys.push(publicKey);
+                    acc.apiKeysFlags[publicKey.getFingerprint()] = Flags;
+                }
+                return acc;
+            },
+            { apiKeys: [], apiKeysFlags: Object.create(null) }
+        );
         const [unarmoredKeys, keysExpired] = await Promise.all([
             getRawInternalKeys(config),
             allKeysExpired(contactKeys)
@@ -144,6 +154,7 @@ const ContactEmailSettingsModal = ({ userKeysList, contactID, properties, emailP
             sign,
             email: Email,
             keys: { api: apiKeys, pinned: contactKeys },
+            apiKeysFlags,
             trustedFingerprints,
             isPGPExternal: externalUser,
             isPGPInternal: internalUser,

--- a/src/app/components/ContactEmailSettingsModal.js
+++ b/src/app/components/ContactEmailSettingsModal.js
@@ -46,7 +46,7 @@ const keyComparator = (originalKeys = [], trustedFingerprints = []) => (firstKey
     const isSecondKeyTrusted = trustedFingerprints.includes(secondKeyFingerprint);
     if (isFirstKeyTrusted ^ isSecondKeyTrusted) {
         // the trusted key takes preference
-        return isFirstKeyTrusted ? -1 : +1;
+        return isFirstKeyTrusted ? -1 : 1;
     }
     if (isFirstKeyTrusted && isSecondKeyTrusted) {
         // preserve order in trustedFingerprints
@@ -58,7 +58,7 @@ const keyComparator = (originalKeys = [], trustedFingerprints = []) => (firstKey
         );
         return firstKeyTrustedIndex - secondKeyTrustedIndex;
     }
-    // if none are trusted, preserve API order
+    // if none is trusted, preserve API order
     const firstKeyOriginalIndex = originalKeys.findIndex((key) => key.getFingerprint() === firstKeyFingerprint);
     const secondKeyOriginalIndex = originalKeys.findIndex((key) => key.getFingerprint() === secondKeyFingerprint);
     return firstKeyOriginalIndex - secondKeyOriginalIndex;
@@ -159,6 +159,8 @@ const ContactEmailSettingsModal = ({ userKeysList, contactID, properties, emailP
             trustedFingerprints,
             isPGPExternal: externalUser,
             isPGPInternal: internalUser,
+            isPGPExternalWithWKDKeys: externalUser && !!apiKeys.length,
+            isPGPExternalWithoutWKDKeys: externalUser && !apiKeys.length,
             pgpAddressDisabled: isDisabledUser(config),
             noPrimary: hasNoPrimary(unarmoredKeys, contactKeys),
             keysExpired

--- a/src/app/components/ContactEmailSettingsModal.js
+++ b/src/app/components/ContactEmailSettingsModal.js
@@ -119,9 +119,7 @@ const ContactEmailSettingsModal = ({ userKeysList, contactID, properties, emailP
 
     /**
      * Collect keys from the model to save
-     * @param {String} group a
-        // prepare keys retrieved from the API
-        const apiKeysConfig =ttach to the current email address
+     * @param {String} group attached to the current email address
      * @returns {Array} key properties to save in the vCard
      */
     const getKeysProperties = (group) => {
@@ -132,7 +130,7 @@ const ContactEmailSettingsModal = ({ userKeysList, contactID, properties, emailP
     };
 
     /**
-     * Save send preferences
+     * Save relevant key properties in the vCard
      * @returns {Promise}
      */
     const handleSubmit = async () => {

--- a/src/app/components/ContactEmailSettingsModal.js
+++ b/src/app/components/ContactEmailSettingsModal.js
@@ -90,10 +90,10 @@ const ContactEmailSettingsModal = ({ userKeysList, contactID, properties, emailP
             { apiKeys: [] }
         );
         const orderedApiKeys = sortApiKeys(apiKeys, trustedFingerprints, verifyOnlyFingerprints);
-        const noTrustedApiKeyCanSend = !orderedApiKeys
-            .filter((key) => trustedFingerprints.has(key.getFingerprint()))
-            .map((key) => !verifyOnlyFingerprints.has(key.getFingerprint()))
-            .filter(Boolean).length;
+        const trustedApiKeys = orderedApiKeys.filter((key) => trustedFingerprints.has(key.getFingerprint()));
+        const noTrustedApiKeyCanSend = !trustedApiKeys.length
+            ? false
+            : !trustedApiKeys.map((key) => !verifyOnlyFingerprints.has(key.getFingerprint())).filter(Boolean).length;
 
         setModel({
             mimeType,
@@ -180,10 +180,11 @@ const ContactEmailSettingsModal = ({ userKeysList, contactID, properties, emailP
                 return canSend;
             })
             .filter(Boolean).length;
-        const noTrustedApiKeyCanSend = !model.keys.api
-            .filter((key) => model.trustedFingerprints.has(key.getFingerprint()))
-            .map((key) => !model.verifyOnlyFingerprints.has(key.getFingerprint()))
-            .filter(Boolean).length;
+        const trustedApiKeys = model.keys.api.filter((key) => model.trustedFingerprints.has(key.getFingerprint()));
+        const noTrustedApiKeyCanSend = !trustedApiKeys.length
+            ? false
+            : !trustedApiKeys.map((key) => !model.verifyOnlyFingerprints.has(key.getFingerprint())).filter(Boolean)
+                  .length;
         setModel((model) => ({
             ...model,
             noPinnedKeyCanSend,

--- a/src/app/components/ContactKeysTable.js
+++ b/src/app/components/ContactKeysTable.js
@@ -12,6 +12,8 @@ import { describe } from 'proton-shared/lib/keys/keysAlgorithm';
 
 import KeyWarningIcon from './KeyWarningIcon';
 
+import { KEY_FLAGS } from 'proton-shared/lib/constants';
+
 const ContactKeysTable = ({ model, setModel }) => {
     const [keys, setKeys] = useState([]);
     const header = [
@@ -43,9 +45,14 @@ const ContactKeysTable = ({ model, setModel }) => {
                     const isActive = !index && !isExpired && (totalApiKeys ? true : model.encrypt);
                     const isWKD = model.isPGPExternal && index < totalApiKeys;
                     const isTrusted = index < totalApiKeys ? model.trustedFingerprints.includes(fingerprint) : true;
+                    const isVerificationOnly =
+                        index < totalApiKeys && !(model.apiKeysFlags[fingerprint] & KEY_FLAGS.ENABLE_ENCRYPTION);
                     const isUploaded = index >= totalApiKeys;
                     const canBeActive =
-                        !!index && !isExpired && (index < totalApiKeys ? isTrusted : !totalApiKeys && model.encrypt);
+                        !!index &&
+                        !isExpired &&
+                        !isVerificationOnly &&
+                        (index < totalApiKeys ? isTrusted : !totalApiKeys && model.encrypt);
                     const canBeTrusted = !isTrusted && !isUploaded;
                     const canBeUntrusted = isTrusted && !isUploaded;
                     return {
@@ -58,6 +65,7 @@ const ContactKeysTable = ({ model, setModel }) => {
                         isExpired,
                         isRevoked,
                         isTrusted,
+                        isVerificationOnly,
                         isUploaded,
                         canBeActive,
                         canBeTrusted,
@@ -90,6 +98,7 @@ const ContactKeysTable = ({ model, setModel }) => {
                         isExpired,
                         isRevoked,
                         isTrusted,
+                        isVerificationOnly,
                         isUploaded,
                         canBeActive,
                         canBeTrusted,
@@ -179,6 +188,9 @@ const ContactKeysTable = ({ model, setModel }) => {
                             algo,
                             <React.Fragment key={fingerprint}>
                                 {isActive ? <Badge>{c('Key badge').t`Active`}</Badge> : null}
+                                {isVerificationOnly ? (
+                                    <Badge type="warning">{c('Key badge').t`Verification only`}</Badge>
+                                ) : null}
                                 {isWKD ? <Badge>{c('Key badge').t`WKD`}</Badge> : null}
                                 {isTrusted ? <Badge>{c('Key badge').t`Trusted`}</Badge> : null}
                             </React.Fragment>,

--- a/src/app/components/ContactKeysTable.js
+++ b/src/app/components/ContactKeysTable.js
@@ -40,11 +40,11 @@ const ContactKeysTable = ({ model, setModel }) => {
                     const algoInfo = publicKey.getAlgorithmInfo();
                     const algo = describe(algoInfo);
                     const fingerprint = publicKey.getFingerprint();
-                    const isPrimary = !index && !isExpired && !(model.isPGPExternal && !model.encrypt);
+                    const isActive = !index && !isExpired && (totalApiKeys ? true : model.encrypt);
                     const isWKD = model.isPGPExternal && index < totalApiKeys;
                     const isTrusted = index < totalApiKeys ? model.trustedFingerprints.includes(fingerprint) : true;
                     const isUploaded = index >= totalApiKeys;
-                    const canBePrimary =
+                    const canBeActive =
                         !!index && !isExpired && (index < totalApiKeys ? isTrusted : !totalApiKeys && model.encrypt);
                     const canBeTrusted = !isTrusted && !isUploaded;
                     const canBeUntrusted = isTrusted && !isUploaded;
@@ -53,13 +53,13 @@ const ContactKeysTable = ({ model, setModel }) => {
                         fingerprint,
                         algo,
                         creationTime,
-                        isPrimary,
+                        isActive,
                         isWKD,
                         isExpired,
                         isRevoked,
                         isTrusted,
                         isUploaded,
-                        canBePrimary,
+                        canBeActive,
                         canBeTrusted,
                         canBeUntrusted
                     };
@@ -84,14 +84,14 @@ const ContactKeysTable = ({ model, setModel }) => {
                         fingerprint,
                         algo,
                         creationTime,
-                        isPrimary,
+                        isActive,
                         isWKD,
                         publicKey,
                         isExpired,
                         isRevoked,
                         isTrusted,
                         isUploaded,
-                        canBePrimary,
+                        canBeActive,
                         canBeTrusted,
                         canBeUntrusted
                     }) => {
@@ -110,8 +110,8 @@ const ContactKeysTable = ({ model, setModel }) => {
                                     downloadFile(blob, filename);
                                 }
                             },
-                            canBePrimary && {
-                                text: c('Action').t`Make primary`,
+                            canBeActive && {
+                                text: c('Action').t`Use for encryption`,
                                 onClick() {
                                     const apiIndex = model.keys.api.findIndex(
                                         (key) => key.getFingerprint() === fingerprint
@@ -178,7 +178,7 @@ const ContactKeysTable = ({ model, setModel }) => {
                             isValid(creation) ? format(creation, 'PP', { locale: dateLocale }) : '-',
                             algo,
                             <React.Fragment key={fingerprint}>
-                                {isPrimary ? <Badge>{c('Key badge').t`Primary`}</Badge> : null}
+                                {isActive ? <Badge>{c('Key badge').t`Active`}</Badge> : null}
                                 {isWKD ? <Badge>{c('Key badge').t`WKD`}</Badge> : null}
                                 {isTrusted ? <Badge>{c('Key badge').t`Trusted`}</Badge> : null}
                             </React.Fragment>,

--- a/src/app/components/ContactKeysTable.js
+++ b/src/app/components/ContactKeysTable.js
@@ -152,7 +152,7 @@ const ContactKeysTable = ({ model, setModel }) => {
                             canBeTrusted && {
                                 text: c('Action').t`Trust`,
                                 onClick() {
-                                    const trustedFingerprints = new Set([...model.trustedFingerprints]);
+                                    const trustedFingerprints = new Set(model.trustedFingerprints);
                                     trustedFingerprints.add(fingerprint);
                                     setModel({ ...model, trustedFingerprints });
                                 }
@@ -160,7 +160,7 @@ const ContactKeysTable = ({ model, setModel }) => {
                             canBeUntrusted && {
                                 text: c('Action').t`Untrust`,
                                 onClick() {
-                                    const trustedFingerprints = new Set([...model.trustedFingerprints]);
+                                    const trustedFingerprints = new Set(model.trustedFingerprints);
                                     trustedFingerprints.delete(fingerprint);
                                     setModel({ ...model, trustedFingerprints });
                                 }
@@ -168,9 +168,9 @@ const ContactKeysTable = ({ model, setModel }) => {
                             isUploaded && {
                                 text: c('Action').t`Remove`,
                                 onClick() {
-                                    const trustedFingerprints = new Set([...model.trustedFingerprints]);
-                                    const expiredFingerprints = new Set([...model.expiredFingerprints]);
-                                    const revokedFingerprints = new Set([...model.revokedFingerprints]);
+                                    const trustedFingerprints = new Set(model.trustedFingerprints);
+                                    const expiredFingerprints = new Set(model.expiredFingerprints);
+                                    const revokedFingerprints = new Set(model.revokedFingerprints);
                                     trustedFingerprints.delete(fingerprint);
                                     expiredFingerprints.delete(fingerprint);
                                     revokedFingerprints.delete(fingerprint);

--- a/src/app/components/ContactKeysTable.js
+++ b/src/app/components/ContactKeysTable.js
@@ -186,8 +186,6 @@ const ContactKeysTable = ({ model, setModel }) => {
                                 <KeyWarningIcon
                                     className="mr0-5 flex-item-noshrink"
                                     publicKey={publicKey}
-                                    isExpired={isExpired}
-                                    isRevoked={isRevoked}
                                     email={model.email}
                                 />
                                 <span className="flex-item-fluid ellipsis">{fingerprint}</span>
@@ -203,6 +201,8 @@ const ContactKeysTable = ({ model, setModel }) => {
                                 ) : null}
                                 {isWKD ? <Badge>{c('Key badge').t`WKD`}</Badge> : null}
                                 {isTrusted ? <Badge>{c('Key badge').t`Trusted`}</Badge> : null}
+                                {isRevoked ? <Badge type="error">{c('Key badge').t`Revoked`}</Badge> : null}
+                                {isExpired ? <Badge type="error">{c('Key badge').t`Expired`}</Badge> : null}
                             </React.Fragment>,
                             <DropdownActions key={fingerprint} className="pm-button--small" list={list} />
                         ].filter(Boolean);

--- a/src/app/components/ContactKeysTable.js
+++ b/src/app/components/ContactKeysTable.js
@@ -120,7 +120,7 @@ const ContactKeysTable = ({ model, setModel }) => {
                                 }
                             },
                             canBeActive && {
-                                text: c('Action').t`Use for encryption`,
+                                text: c('Action').t`Use for sending`,
                                 onClick() {
                                     const apiIndex = model.keys.api.findIndex(
                                         (key) => key.getFingerprint() === fingerprint

--- a/src/app/components/ContactKeysTable.js
+++ b/src/app/components/ContactKeysTable.js
@@ -11,8 +11,6 @@ import { describe } from 'proton-shared/lib/keys/keysAlgorithm';
 
 import KeyWarningIcon from './KeyWarningIcon';
 
-import { KEY_FLAGS } from 'proton-shared/lib/constants';
-
 const ContactKeysTable = ({ model, setModel }) => {
     const [keys, setKeys] = useState([]);
     const { isNarrow, isTinyMobile } = useActiveBreakpoint();
@@ -36,14 +34,19 @@ const ContactKeysTable = ({ model, setModel }) => {
                     const isTrusted = model.trustedFingerprints.has(fingerprint);
                     const isExpired = model.expiredFingerprints.has(fingerprint);
                     const isRevoked = model.revokedFingerprints.has(fingerprint);
-                    const isActive = !index && !isExpired && (totalApiKeys ? true : model.encrypt);
+                    const isVerificationOnly = model.verifyOnlyFingerprints.has(fingerprint);
+                    const isActive =
+                        !index &&
+                        !isExpired &&
+                        !isRevoked &&
+                        !isVerificationOnly &&
+                        (totalApiKeys ? true : model.encrypt);
                     const isWKD = model.isPGPExternal && index < totalApiKeys;
-                    const isVerificationOnly =
-                        index < totalApiKeys && !(model.apiKeysFlags[fingerprint] & KEY_FLAGS.ENABLE_ENCRYPTION);
                     const isUploaded = index >= totalApiKeys;
                     const canBeActive =
                         !!index &&
                         !isExpired &&
+                        !isRevoked &&
                         !isVerificationOnly &&
                         (index < totalApiKeys ? isTrusted : !totalApiKeys && model.encrypt);
                     const canBeTrusted = !isTrusted && !isUploaded;

--- a/src/app/components/ContactKeysTable.js
+++ b/src/app/components/ContactKeysTable.js
@@ -27,9 +27,10 @@ const ContactKeysTable = ({ model, setModel }) => {
      * Extract keys info from model.keys to define table body
      */
     const parse = async () => {
-        const allKeys = uniqueBy([...model.keys.api, ...model.keys.pinned], (publicKey) => publicKey.getFingerprint());
+        const allKeys = model.isPGPInternal ? [...model.keys.api] : [...model.keys.api, ...model.keys.pinned];
+        const uniqueKeys = uniqueBy(allKeys, (publicKey) => publicKey.getFingerprint());
         const parsedKeys = await Promise.all(
-            allKeys.map(async (publicKey, index) => {
+            uniqueKeys.map(async (publicKey, index) => {
                 try {
                     const date = +serverTime();
                     const creationTime = publicKey.getCreationTime();

--- a/src/app/components/ContactKeysTable.js
+++ b/src/app/components/ContactKeysTable.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Table, TableBody, TableRow, Badge, DropdownActions, useActiveBreakpoint } from 'react-components';
+import { Table, TableBody, TableRow, Badge, DropdownActions, useActiveBreakpoint, classnames } from 'react-components';
 import PropTypes from 'prop-types';
 import { c } from 'ttag';
 import { isValid, format } from 'date-fns';
@@ -16,7 +16,7 @@ import { KEY_FLAGS } from 'proton-shared/lib/constants';
 
 const ContactKeysTable = ({ model, setModel }) => {
     const [keys, setKeys] = useState([]);
-    const { isNarrow } = useActiveBreakpoint();
+    const { isNarrow, isTinyMobile } = useActiveBreakpoint();
 
     const totalApiKeys = model.keys.api.length;
 
@@ -85,10 +85,11 @@ const ContactKeysTable = ({ model, setModel }) => {
                 <tr>
                     <th scope="col" className="ellipsis">{c('Table header').t`Fingerprint`}</th>
                     {!isNarrow && <th scope="col" className="ellipsis">{c('Table header').t`Created`}</th>}
-                    <th scope="col" className="ellipsis">{c('Table header').t`Expires`}</th>
+                    {!isTinyMobile && <th scope="col" className="ellipsis">{c('Table header').t`Expires`}</th>}
                     {!isNarrow && <th scope="col" className="ellipsis">{c('Table header').t`Type`}</th>}
                     <th scope="col" className="ellipsis">{c('Table header').t`Status`}</th>
-                    <th scope="col" className="ellipsis">{c('Table header').t`Actions`}</th>
+                    <th scope="col" className={classnames(['ellipsis', isNarrow && 'w40'])}>{c('Table header')
+                        .t`Actions`}</th>
                 </tr>
             </thead>
             <TableBody>
@@ -192,7 +193,8 @@ const ContactKeysTable = ({ model, setModel }) => {
                                 <span className="flex-item-fluid ellipsis">{fingerprint}</span>
                             </div>,
                             !isNarrow && (isValid(creation) ? format(creation, 'PP', { locale: dateLocale }) : '-'),
-                            isValid(expiration) ? format(expiration, 'PP', { locale: dateLocale }) : '-',
+                            !isTinyMobile &&
+                                (isValid(expiration) ? format(expiration, 'PP', { locale: dateLocale }) : '-'),
                             !isNarrow && algo,
                             <React.Fragment key={fingerprint}>
                                 {isActive ? <Badge>{c('Key badge').t`Active`}</Badge> : null}

--- a/src/app/components/ContactPgpSettings.js
+++ b/src/app/components/ContactPgpSettings.js
@@ -60,7 +60,7 @@ const ContactPgpSettings = ({ model, setModel }) => {
                         .t`Setting up PGP allows you to send end-to-end encrypted emails with a non-Protonmail user that uses a PGP compatible service.`}
                 </Alert>
             )}
-            {!!model.keys.pinned.length && model.noPrimary && (
+            {!!model.keys.pinned.length && model.noTrustedApiKeyCanSend && (
                 <Alert type="warning">{c('Info')
                     .t`Address Verification with Trusted Keys is enabled for this address. To be able to send to this address, first trust public keys that can be used for sending.`}</Alert>
             )}

--- a/src/app/components/ContactPgpSettings.js
+++ b/src/app/components/ContactPgpSettings.js
@@ -106,7 +106,7 @@ const ContactPgpSettings = ({ model, setModel }) => {
                         <Toggle
                             id="encrypt-toggle"
                             checked={model.encrypt}
-                            disabled={!model.keys.pinned.length || model.noPinnedKeyCanSend}
+                            disabled={!model.keys.pinned.length || noPinnedKeyCanSend}
                             onChange={({ target }) =>
                                 setModel({
                                     ...model,

--- a/src/app/components/ContactPgpSettings.js
+++ b/src/app/components/ContactPgpSettings.js
@@ -8,7 +8,6 @@ import ContactSchemeSelect from './ContactSchemeSelect';
 import ContactKeysTable from './ContactKeysTable';
 
 const ContactPgpSettings = ({ model, setModel }) => {
-    console.log(model.noTrustedApiKeyCanSend);
     const { createNotification } = useNotifications();
     const hasApiKeys = !!model.keys.api.length;
     const hasPinnedKeys = !!model.keys.pinned.length;

--- a/src/app/components/ContactPgpSettings.js
+++ b/src/app/components/ContactPgpSettings.js
@@ -80,10 +80,9 @@ const ContactPgpSettings = ({ model, setModel }) => {
                 <Alert learnMore="https://protonmail.com/support/knowledge-base/how-to-use-pgp/">{c('Info')
                     .t`Only change these settings if you are using PGP with non-ProtonMail recipients.`}</Alert>
             )}
-            {model.keysExpired && (
-                <Alert type="warning" learnMore="https://protonmail.com/support/knowledge-base/how-to-use-pgp/">{c(
-                    'Info'
-                ).t`All uploaded keys are expired or revoked! Encryption is automatically disabled.`}</Alert>
+            {model.isPGPExternalWithoutWKDKeys && model.keysExpired && (
+                <Alert type="error" learnMore="https://protonmail.com/support/knowledge-base/how-to-use-pgp/">{c('Info')
+                    .t`All uploaded keys are expired or revoked! Encryption is automatically disabled.`}</Alert>
             )}
             {!hasApiKeys && (
                 <Row>
@@ -118,7 +117,7 @@ const ContactPgpSettings = ({ model, setModel }) => {
                         <Info
                             className="ml0-5"
                             title={c('Tooltip')
-                                .t`Digitally signing emails helps authentify that messages are sent by you`}
+                                .t`Digitally signing emails helps authenticating that messages are sent by you`}
                         />
                     </Label>
                     <Field>

--- a/src/app/components/ContactPgpSettings.js
+++ b/src/app/components/ContactPgpSettings.js
@@ -64,7 +64,7 @@ const ContactPgpSettings = ({ model, setModel }) => {
                         .t`Setting up PGP allows you to send end-to-end encrypted emails with a non-Protonmail user that uses a PGP compatible service.`}
                 </Alert>
             )}
-            {!!model.keys.length && model.noPrimary && (
+            {!!model.keys.pinned.length && model.noPrimary && (
                 <Alert type="warning">{c('Info')
                     .t`Address Verification with Trusted Keys is enabled for this address. To be able to send to this address, first trust public keys that can be used for sending.`}</Alert>
             )}
@@ -99,7 +99,7 @@ const ContactPgpSettings = ({ model, setModel }) => {
                         <Toggle
                             id="encrypt-toggle"
                             checked={model.encrypt}
-                            disabled={!model.keys.length || model.keysExpired}
+                            disabled={!model.keys.pinned.length || model.keysExpired}
                             onChange={({ target }) =>
                                 setModel({
                                     ...model,

--- a/src/app/components/ContactPgpSettings.js
+++ b/src/app/components/ContactPgpSettings.js
@@ -8,6 +8,7 @@ import ContactSchemeSelect from './ContactSchemeSelect';
 import ContactKeysTable from './ContactKeysTable';
 
 const ContactPgpSettings = ({ model, setModel }) => {
+    console.log(model.noTrustedApiKeyCanSend);
     const { createNotification } = useNotifications();
     const hasApiKeys = !!model.keys.api.length;
     const hasPinnedKeys = !!model.keys.pinned.length;
@@ -70,7 +71,7 @@ const ContactPgpSettings = ({ model, setModel }) => {
             )}
             {hasApiKeys && (
                 <Alert learnMore="https://protonmail.com/support/knowledge-base/address-verification/">{c('Info')
-                    .t`To use Address Verification, you must trust one or more available public keys, including the primary key for this address. This prevents the encrypted keys from being faked.`}</Alert>
+                    .t`To use Address Verification, you must trust one or more available public keys, including the one you want to use for sending. This prevents the encrypted keys from being faked.`}</Alert>
             )}
             {!hasApiKeys && !model.sign && (
                 <Alert learnMore="https://protonmail.com/support/knowledge-base/how-to-use-pgp/">{c('Info')

--- a/src/app/components/ContactPgpSettings.js
+++ b/src/app/components/ContactPgpSettings.js
@@ -154,7 +154,7 @@ const ContactPgpSettings = ({ model, setModel }) => {
                     />
                 </Label>
                 <Field className="onmobile-mt0-5">
-                    {model.isPGPExternal && <SelectKeyFiles onFiles={handleUploadKeys} multiple={true} />}
+                    {model.isPGPExternalWithoutWKDKeys && <SelectKeyFiles onFiles={handleUploadKeys} multiple={true} />}
                 </Field>
             </Row>
             {(hasApiKeys || hasPinnedKeys) && <ContactKeysTable model={model} setModel={setModel} />}

--- a/src/app/components/ContactPgpSettings.js
+++ b/src/app/components/ContactPgpSettings.js
@@ -145,7 +145,9 @@ const ContactPgpSettings = ({ model, setModel }) => {
                             .t`Upload a public key to enable sending end-to-end encrypted emails to this email`}
                     />
                 </Label>
-                <Field>{model.isPGPExternal && <SelectKeyFiles onFiles={handleUploadKeys} multiple={true} />}</Field>
+                <Field className="onmobile-mt0-5">
+                    {model.isPGPExternal && <SelectKeyFiles onFiles={handleUploadKeys} multiple={true} />}
+                </Field>
             </Row>
             {(hasApiKeys || hasPinnedKeys) && <ContactKeysTable model={model} setModel={setModel} />}
             {!hasApiKeys && (

--- a/src/app/components/KeyWarningIcon.js
+++ b/src/app/components/KeyWarningIcon.js
@@ -5,7 +5,7 @@ import { Icon, Tooltip } from 'react-components';
 
 import { emailMismatch } from '../helpers/pgp';
 
-const KeyWarningIcon = ({ publicKey, isRevoked, isExpired, email, ...rest }) => {
+const KeyWarningIcon = ({ publicKey, email, ...rest }) => {
     const icon = <Icon name="attention" fill="attention" {...rest} />;
     const assignedEmails = emailMismatch(publicKey, email); // Returns Boolean|Array<String>
 
@@ -14,21 +14,11 @@ const KeyWarningIcon = ({ publicKey, isRevoked, isExpired, email, ...rest }) => 
         return <Tooltip title={c('PGP key warning').t`This key is assigned to ${emails}`}>{icon}</Tooltip>;
     }
 
-    if (isRevoked) {
-        return <Tooltip title={c('PGP key warning').t`This key is revoked`}>{icon}</Tooltip>;
-    }
-
-    if (isExpired) {
-        return <Tooltip title={c('PGP key warning').t`This key is expired`}>{icon}</Tooltip>;
-    }
-
     return null;
 };
 
 KeyWarningIcon.propTypes = {
     publicKey: PropTypes.object.isRequired,
-    isExpired: PropTypes.bool,
-    isRevoked: PropTypes.bool,
     email: PropTypes.string.isRequired
 };
 

--- a/src/app/containers/ContactsContainer.js
+++ b/src/app/containers/ContactsContainer.js
@@ -230,7 +230,7 @@ const ContactsContainer = ({ location, history }) => {
     );
 
     const contactPlaceHolderComponent = isDesktop && !contactComponent && !!formattedContacts.length && (
-        <ContactPlacepaholder
+        <ContactPlaceholder
             history={history}
             user={user}
             userKeysList={userKeysList}

--- a/src/app/containers/ContactsContainer.js
+++ b/src/app/containers/ContactsContainer.js
@@ -230,7 +230,7 @@ const ContactsContainer = ({ location, history }) => {
     );
 
     const contactPlaceHolderComponent = isDesktop && !contactComponent && !!formattedContacts.length && (
-        <ContactPlaceholder
+        <ContactPlacepaholder
             history={history}
             user={user}
             userKeysList={userKeysList}

--- a/src/app/helpers/pgp.js
+++ b/src/app/helpers/pgp.js
@@ -1,5 +1,4 @@
 import { RECIPIENT_TYPE, KEY_FLAGS } from 'proton-shared/lib/constants';
-import { arrayToBinaryString, encodeBase64 } from 'pmcrypto';
 import { serverTime } from 'pmcrypto/lib/serverTime';
 import { toBitMap } from 'proton-shared/lib/helpers/object';
 
@@ -46,17 +45,9 @@ export const emailMismatch = ({ users = [] }, currentEmail) => {
     return keyEmails;
 };
 
-export const hasNoPrimary = (unarmoredKeys = [], contactKeys = []) => {
-    if (!unarmoredKeys.length) {
-        return false;
-    }
-    const keys = contactKeys.map((value) => encodeBase64(arrayToBinaryString(value)));
-    return !unarmoredKeys.some((k) => keys.includes(k));
-};
-
 /**
  * Sort list of keys retrieved from the API. Trusted keys take preference.
- * For two keys, both trusted or not, non-verify-only keys take preference
+ * For two keys such that both are either trusted or not, non-verify-only keys take preference
  * @param {Array} keys
  * @param {Set} trustedFingerprints
  * @param {Set} verifyOnlyFingerprints
@@ -105,8 +96,7 @@ export const sortPinnedKeys = (keys = [], expiredFingerprints, revokedFingerprin
 /**
  * Given a key, return its expiration and revoke status
  * @param publicKey
- * @param date          Unix timestamp
- * @returns {Promise<{expired: boolean, revoked: boolean}>}
+ * @returns {Promise<{ isExpired: boolean, isRevoked: boolean}>}
  */
 export const getKeyEncryptStatus = async (publicKey) => {
     const date = +serverTime();

--- a/src/app/helpers/properties.js
+++ b/src/app/helpers/properties.js
@@ -1,5 +1,5 @@
 // Vcard fields for which we keep track of PREF parameter
-const FIELDS_WITH_PREF = ['fn', 'email', 'tel', 'adr'];
+const FIELDS_WITH_PREF = ['fn', 'email', 'tel', 'adr', 'key'];
 
 /**
  * Given a Vcard field, return true if we take into consideration its PREF parameters

--- a/src/app/helpers/properties.js
+++ b/src/app/helpers/properties.js
@@ -64,7 +64,28 @@ export const addPref = (properties = []) => {
 /**
  * Function that sorts properties by preference
  */
-export const sortByPref = (firstEl, secondEl) => +firstEl.pref <= +secondEl.pref;
+export const sortByPref = (firstEl, secondEl) => firstEl.pref - secondEl.pref;
+
+/**
+ * Given a list of properties with preference, reorder them according to the preference
+ * @param {Array} properties
+ * @returns {Array}
+ */
+export const reOrderByPref = (properties) => {
+    const { withPref, withoutPref } = properties.reduce(
+        (acc, property) => {
+            if (FIELDS_WITH_PREF.includes(property.field)) {
+                acc.withPref.push(property);
+            } else {
+                acc.withoutPref.push(property);
+            }
+            return acc;
+        },
+        { withPref: [], withoutPref: [] }
+    );
+
+    return withPref.sort(sortByPref).concat(withoutPref);
+};
 
 /**
  * Generate new group name that doesn't exist

--- a/src/app/helpers/property.js
+++ b/src/app/helpers/property.js
@@ -81,6 +81,13 @@ export const formatAdr = (adr = []) => {
         .join(', ');
 };
 
+/**
+ * Given an array of vCard properties, extract the keys and key-related fields
+ * relevant for an email address
+ * @param {Array} properties
+ * @param {String} emailGroup       Group that characterizes the email address
+ * @returns {Promise<{scheme: String, encrypt: Boolean, mimeType: String, pinnedKeys: Array}>}
+ */
 export const getKeysFromProperties = async (properties, emailGroup) => {
     const { pinnedKeyPromises, mimeType, encrypt, scheme } = properties
         .filter(({ field, group }) => VCARD_KEY_FIELDS.includes(field) && group === emailGroup)

--- a/src/app/helpers/property.js
+++ b/src/app/helpers/property.js
@@ -1,3 +1,8 @@
+import { getKeys, arrayToBinaryString, binaryStringToArray, decodeBase64, encodeBase64 } from 'pmcrypto';
+import { VCARD_KEY_FIELDS } from '../constants';
+import { noop } from 'proton-shared/lib/helpers/function';
+import { sortByPref } from './properties';
+
 /**
  * ICAL library can crash if the value saved in the vCard is improperly formatted
  * If it crash we get the raw value from jCal key
@@ -75,3 +80,68 @@ export const formatAdr = (adr = []) => {
         .map((value) => value.trim())
         .join(', ');
 };
+
+export const getKeysFromProperties = async (properties, emailGroup) => {
+    const { pinnedKeyPromises, mimeType, encrypt, scheme } = properties
+        .filter(({ field, group }) => VCARD_KEY_FIELDS.includes(field) && group === emailGroup)
+        .reduce(
+            (acc, { field, value, pref }) => {
+                if (field === 'key' && value) {
+                    const [, base64 = ''] = value.split(',');
+                    const key = binaryStringToArray(decodeBase64(base64));
+
+                    if (key.length) {
+                        const promise = getKeys(key)
+                            .then(([publicKey]) => ({ publicKey, pref }))
+                            .catch(noop);
+                        acc.pinnedKeyPromises.push(promise);
+                    }
+
+                    return acc;
+                }
+
+                if (field === 'x-pm-encrypt' && value) {
+                    acc.encrypt = value === 'true';
+                    return acc;
+                }
+
+                if (field === 'x-pm-sign' && value) {
+                    acc.sign = value === 'true';
+                    return acc;
+                }
+
+                if (field === 'x-pm-scheme' && value) {
+                    acc.scheme = value;
+                    return acc;
+                }
+
+                if (field === 'x-pm-mimetype' && value) {
+                    acc.mimeType = value;
+                    return acc;
+                }
+
+                return acc;
+            },
+            { pinnedKeyPromises: [], mimeType: '', encrypt: false, scheme: '' } // Default values
+        );
+    const pinnedKeys = (await Promise.all(pinnedKeyPromises))
+        .filter(Boolean)
+        .sort(sortByPref)
+        .map(({ publicKey }) => publicKey);
+
+    return { pinnedKeys, mimeType, encrypt, scheme };
+};
+
+/**
+ * Transform a key into a vCard property
+ * @param {} publicKey      A PGP key
+ * @param {String} group
+ * @param {Number} index
+ * @returns { field, pref, value, group }
+ */
+export const toKeyProperty = ({ publicKey, group, index }) => ({
+    field: 'key',
+    value: `data:application/pgp-keys;base64,${encodeBase64(arrayToBinaryString(publicKey.toPacketlist().write()))}`,
+    group,
+    pref: `${index + 1}` // order is important
+});


### PR DESCRIPTION
Test server: https://eta.protonmail.blue/contacts
Note for testers: protonmail.com addresses behave as WKD addresses for protonmail.blue users. I.e., if in your blue account you have a protonmail contact, it should have WKD keys.

Implementation of WKD according to the one in v3: https://github.com/ProtonMail/Angular/pull/9063 , with a few slight improvements. The flow for the PGP settings modal (the one that opens when clicking on advanced settings for an email address) in the three possible cases is as follows:

# Generic:
A flag 'ACTIVE' is displayed for the key that is currently used for encryption, if any. In v3 it was 'PRIMARY', but it was only displayed for pinned keys, which was a bit confusing. "Set as primary" has been substituted by "Use for sending". This has been discussed with @twiss.

The PGP settings modal should be responsive now, as requested in #254.

# Internal user:
- We should only see the keys provided by protonmail. Notice this is not the case in v3, where upon trusting some key, we can also manually upload an external key. I don't see the point of allowing that, since nothing can be done with that key (it can't be used for encryption). So I think it's better not to allow uploading keys for internal users, and not displaying them for internal contacts that have external keys in the vcard (which could be uploaded using v3).
- If some key is marked as invalid for encryption by the API, a flag 'VERIFICATION ONLY' should be displayed. Such a key cannot be selected as used for sending, unless it's the only trusted key, in which case the warning message: "Address Verification with Trusted Keys is enabled for this address. To be able to send to this address, first trust public keys that can be used for sending." will be shown.
- It's possible to trust or untrust these keys, and whenever more than one is trusted, it should be possible to select one of them for encryption when sending to the corresponding address (i.e. mark it as active). When trusted, a flag 'TRUSTED' is displayed.
- If only one key is trusted, it should be automatically selected as active.
- If no keys are trusted, the first one in the list is the active one. No other can be selected as active.

# External user with WKD keys:
- We should see the keys retrieved by protonmail from WKD servers, and also maybe manually uploaded keys. Although it's not possible to upload new external keys, there could be external keys in the vcard (maybe because the address did not have WKD keys before, so it's possible to add external keys for those). These keys cannot be selected as used for sending (WKD keys are used by default).
- The WKD keys have a flag 'WKD'. The manually uploaded keys have a 'TRUSTED' flag (they are trusted since you manually uploaded them).
- The WKD keys can be trusted/untrusted, and if more than one WKD key is trusted it should be possible to select which one you want to use for sending (I could not test this since it seems the API is never returning more than one WKD key).

# External user without WKD keys:
- We should see the keys that are stored in the vcard. All of them must show the flag 'TRUSTED'.
- We can manually upload more keys, or remove some of them.
- If the encrypt toggle is activated, the first key in the list becomes 'ACTIVE', and the others can be selected for encryption.


Closes #134.
Closes #254
Closes #367