### PR TITLE
Possibility of deleting current (not checked) contact

### DIFF
--- a/src/app/components/ContactToolbar.js
+++ b/src/app/components/ContactToolbar.js
@@ -10,20 +10,20 @@ const ContactToolbar = ({
     onCheck,
     onDelete,
     checked = false,
-    checkedIDs = [],
+    activeIDs = [],
     contactEmailsMap = {},
     simplified = false
 }) => {
     const handleCheck = ({ target }) => onCheck(target.checked);
 
     const contactEmailsSelected = useMemo(() => {
-        return checkedIDs.reduce((acc, ID) => {
+        return activeIDs.reduce((acc, ID) => {
             if (!contactEmailsMap[ID]) {
                 return acc;
             }
             return acc.concat(contactEmailsMap[ID]);
         }, []);
-    }, [checkedIDs, contactEmailsMap]);
+    }, [activeIDs, contactEmailsMap]);
 
     if (simplified) {
         return (
@@ -44,7 +44,7 @@ const ContactToolbar = ({
                 title={c('Tooltip').t`Delete`}
                 className="toolbar-button"
                 onClick={onDelete}
-                disabled={!checkedIDs.length}
+                disabled={!activeIDs.length}
             >
                 <Icon name="delete" className="toolbar-icon mauto" />
             </button>
@@ -67,7 +67,7 @@ ContactToolbar.propTypes = {
     user: PropTypes.object,
     onCheck: PropTypes.func,
     onDelete: PropTypes.func,
-    checkedIDs: PropTypes.array,
+    activeIDs: PropTypes.array,
     contactEmailsMap: PropTypes.object,
     simplified: PropTypes.bool
 };

--- a/src/app/components/delete/DeleteModal.js
+++ b/src/app/components/delete/DeleteModal.js
@@ -32,6 +32,7 @@ const DeleteModal = ({
             history.replace({ ...location, pathname: '/contacts' });
             await call();
             onUpdateChecked(Object.create(null));
+            rest.onClose();
             return createNotification({ text: c('Success').t`Contacts deleted` });
         }
         const apiSuccess = allSucceded(await api(deleteContacts(activeIDs)));

--- a/src/app/components/delete/DeleteModal.js
+++ b/src/app/components/delete/DeleteModal.js
@@ -6,7 +6,7 @@ import { useApi, useNotifications, useEventManager, useLoading, Alert, ErrorButt
 import { clearContacts, deleteContacts } from 'proton-shared/lib/api/contacts';
 import { allSucceded } from 'proton-shared/lib/api/helpers/response';
 
-const DeleteModal = ({ beDeletedIDs, deleteAll, onDelete, ...rest }) => {
+const DeleteModal = ({ contactIDs = [], deleteAll, onDelete, ...rest }) => {
     const api = useApi();
     const { createNotification } = useNotifications();
     const { call } = useEventManager();
@@ -17,20 +17,20 @@ const DeleteModal = ({ beDeletedIDs, deleteAll, onDelete, ...rest }) => {
     const handleDelete = async () => {
         if (deleteAll) {
             await api(clearContacts());
-            onDelete();
+            onDelete && onDelete();
             await call();
             rest.onClose();
             return createNotification({ text: c('Success').t`Contacts deleted` });
         }
-        const apiSuccess = allSucceded(await api(deleteContacts(beDeletedIDs)));
-        onDelete();
+        const apiSuccess = allSucceded(await api(deleteContacts(contactIDs)));
+        onDelete && onDelete();
         await call();
         rest.onClose();
         if (!apiSuccess) {
             return createNotification({ text: c('Error').t`Some contacts could not be deleted`, type: 'warning' });
         }
         createNotification({
-            text: c('Success').ngettext(msgid`Contact deleted`, `Contacts deleted`, beDeletedIDs.length)
+            text: c('Success').ngettext(msgid`Contact deleted`, `Contacts deleted`, contactIDs.length)
         });
     };
     return (
@@ -45,7 +45,7 @@ const DeleteModal = ({ beDeletedIDs, deleteAll, onDelete, ...rest }) => {
                 {c('Warning').ngettext(
                     msgid`This action will permanently delete the selected contact. Are you sure you want to delete this contact?`,
                     `This action will permanently delete selected contacts. Are you sure you want to delete these contacts?`,
-                    beDeletedIDs.length
+                    contactIDs.length
                 )}
             </Alert>
         </FormModal>
@@ -53,7 +53,7 @@ const DeleteModal = ({ beDeletedIDs, deleteAll, onDelete, ...rest }) => {
 };
 
 DeleteModal.propTypes = {
-    beDeletedIDs: PropTypes.arrayOf(PropTypes.string),
+    contactIDs: PropTypes.arrayOf(PropTypes.string),
     deleteAll: PropTypes.bool,
     onDelete: PropTypes.func
 };

--- a/src/app/components/delete/DeleteModal.js
+++ b/src/app/components/delete/DeleteModal.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { c, msgid } from 'ttag';
+import { useApi, useNotifications, useEventManager, useLoading, Alert, ErrorButton, FormModal } from 'react-components';
+
+import { clearContacts, deleteContacts } from 'proton-shared/lib/api/contacts';
+import { allSucceded } from 'proton-shared/lib/api/helpers/response';
+
+const DeleteModal = ({
+    activeIDs,
+    contactID,
+    contacts,
+    filteredContacts,
+    filteredCheckedIDs,
+    onCheck,
+    onClearSearch,
+    onUpdateChecked,
+    history,
+    location,
+    ...rest
+}) => {
+    const api = useApi();
+    const { createNotification } = useNotifications();
+    const { call } = useEventManager();
+    const [loadingDelete, withLoadingDelete] = useLoading();
+
+    const submit = <ErrorButton type="submit" loading={loadingDelete}>{c('Action').t`Delete`}</ErrorButton>;
+
+    const handleDelete = async () => {
+        if (activeIDs.length === contacts.length) {
+            await api(clearContacts());
+            history.replace({ ...location, pathname: '/contacts' });
+            await call();
+            onUpdateChecked(Object.create(null));
+            return createNotification({ text: c('Success').t`Contacts deleted` });
+        }
+        const apiSuccess = allSucceded(await api(deleteContacts(activeIDs)));
+        if (activeIDs.length === filteredContacts.length) {
+            onClearSearch();
+        }
+        if (contactID && activeIDs.includes(contactID)) {
+            history.replace({ ...location, pathname: '/contacts' });
+        }
+        await call();
+        onCheck(filteredCheckedIDs, false);
+        rest.onClose();
+        if (!apiSuccess) {
+            return createNotification({ text: c('Error').t`Some contacts could not be deleted`, type: 'warning' });
+        }
+        createNotification({
+            text: c('Success').ngettext(msgid`Contact deleted`, `Contacts deleted`, activeIDs.length)
+        });
+    };
+    return (
+        <FormModal
+            title={c('Title').t`Delete`}
+            onSubmit={() => withLoadingDelete(handleDelete())}
+            submit={submit}
+            loading={loadingDelete}
+            {...rest}
+        >
+            <Alert type="warning">
+                {c('Warning').ngettext(
+                    msgid`This action will permanently delete the selected contact. Are you sure you want to delete this contact?`,
+                    `This action will permanently delete selected contacts. Are you sure you want to delete these contacts?`,
+                    activeIDs.length
+                )}
+            </Alert>
+        </FormModal>
+    );
+};
+
+DeleteModal.propTypes = {
+    activeIDs: PropTypes.arrayOf(PropTypes.string),
+    contactID: PropTypes.string,
+    contacts: PropTypes.arrayOf(PropTypes.object),
+    filteredContacts: PropTypes.arrayOf(PropTypes.object),
+    filteredCheckedIDs: PropTypes.arrayOf(PropTypes.string),
+    onCheck: PropTypes.func,
+    onClearSearch: PropTypes.func,
+    onUpdateChecked: PropTypes.func,
+    location: PropTypes.object.isRequired,
+    history: PropTypes.object.isRequired
+};
+
+export default DeleteModal;

--- a/src/app/components/delete/DeleteModal.js
+++ b/src/app/components/delete/DeleteModal.js
@@ -29,7 +29,7 @@ const DeleteModal = ({
     const handleDelete = async () => {
         if (activeIDs.length === contacts.length) {
             await api(clearContacts());
-            history.replace({ ...location, pathname: '/contacts' });
+            history.replace({ ...location, state: { ignoreClose: true }, pathname: '/contacts' });
             await call();
             onUpdateChecked(Object.create(null));
             rest.onClose();
@@ -40,7 +40,7 @@ const DeleteModal = ({
             onClearSearch();
         }
         if (contactID && activeIDs.includes(contactID)) {
-            history.replace({ ...location, pathname: '/contacts' });
+            history.replace({ ...location, state: { ignoreClose: true }, pathname: '/contacts' });
         }
         await call();
         onCheck(filteredCheckedIDs, false);

--- a/src/app/containers/ContactsContainer.js
+++ b/src/app/containers/ContactsContainer.js
@@ -162,20 +162,21 @@ const ContactsContainer = ({ location, history }) => {
     };
 
     const handleDelete = () => {
-        createModal(
-            <DeleteModal
-                activeIDs={activeIDs}
-                contactID={contactID}
-                contacts={contacts}
-                filteredContacts={filteredContacts}
-                filteredCheckedIDs={filteredCheckedIDs}
-                onCheck={handleCheck}
-                onClearSearch={handleClearSearch}
-                onUpdateChecked={setCheckedContacts}
-                history={history}
-                location={location}
-            />
-        );
+        const deleteAll = activeIDs.length === contacts.length;
+        const onDelete = () => {
+            if (deleteAll) {
+                history.replace({ ...location, state: { ignoreClose: true }, pathname: '/contacts' });
+                return setCheckedContacts(Object.create(null));
+            }
+            if (activeIDs.length === filteredContacts.length) {
+                handleClearSearch();
+            }
+            if (contactID && activeIDs.includes(contactID)) {
+                history.replace({ ...location, state: { ignoreClose: true }, pathname: '/contacts' });
+            }
+            handleCheck(filteredCheckedIDs, false);
+        };
+        createModal(<DeleteModal beDeletedIDs={activeIDs} deleteAll={deleteAll} onDelete={onDelete} />);
     };
 
     const handleMerge = () => {


### PR DESCRIPTION
In the last modification to the logic for deleting a contact, we lost in the way the ability to delete the current contact in case it's not checked. This PR recovers this ability. Also, because the delete operation can take some time, it's better to freeze the "confirm deletion" modal while it happens. Otherwise you can go back to the contact view where the deleted contacts are still there