### PR TITLE
Manage prefs properly

### DIFF
--- a/src/app/helpers/decrypt.js
+++ b/src/app/helpers/decrypt.js
@@ -4,7 +4,6 @@ import { sanitizeProperties } from './properties';
 
 import { CONTACT_CARD_TYPE } from 'proton-shared/lib/constants';
 import { SIGNATURE_NOT_VERIFIED, FAIL_TO_READ, FAIL_TO_DECRYPT } from '../constants';
-import { splitKeys } from 'proton-shared/lib/keys/keys';
 
 const { CLEAR_TEXT, ENCRYPTED_AND_SIGNED, ENCRYPTED, SIGNED } = CONTACT_CARD_TYPE;
 
@@ -105,12 +104,4 @@ export const prepareContact = async (contact, { publicKeys, privateKeys }) => {
     );
 
     return { properties: sanitizeProperties(merge(vcards.map(parse))), errors };
-};
-
-export const decryptContactCards = async (contactCards, contactID, keys) => {
-    const { properties, errors } = await prepareContact({ Cards: contactCards }, splitKeys(keys));
-    if (errors.length !== 0) {
-        throw new Error('Error decrypting contact with contactID ', contactID);
-    }
-    return properties;
 };

--- a/src/app/helpers/properties.js
+++ b/src/app/helpers/properties.js
@@ -2,7 +2,9 @@
 const FIELDS_WITH_PREF = ['fn', 'email', 'tel', 'adr'];
 
 /**
- *
+ * Given a Vcard field, return true if we take into consideration its PREF parameters
+ * @param {String} field
+ * @returns {Boolean}
  */
 export const hasPref = (field) => FIELDS_WITH_PREF.includes(field);
 
@@ -62,7 +64,7 @@ export const addPref = (properties = []) => {
 /**
  * Function that sorts properties by preference
  */
-export const sortByPref = (firstEl, secondEl) => firstEl.pref <= secondEl.pref;
+export const sortByPref = (firstEl, secondEl) => +firstEl.pref <= +secondEl.pref;
 
 /**
  * Generate new group name that doesn't exist

--- a/src/app/helpers/properties.js
+++ b/src/app/helpers/properties.js
@@ -1,3 +1,11 @@
+// Vcard fields for which we keep track of PREF parameter
+const FIELDS_WITH_PREF = ['fn', 'email', 'tel', 'adr'];
+
+/**
+ *
+ */
+export const hasPref = (field) => FIELDS_WITH_PREF.includes(field);
+
 /**
  * Make sure we keep only valid properties
  * In case adr property is badly formatted, re-format
@@ -32,9 +40,13 @@ export const sanitizeProperties = (properties = []) => {
  * @param {Array}
  */
 export const addPref = (properties = []) => {
-    const prefs = { email: 0, tel: 0, adr: 0 };
+    const prefs = FIELDS_WITH_PREF.reduce((acc, field) => {
+        acc[field] = 0;
+        return acc;
+    }, Object.create(null));
+
     return properties.map((property) => {
-        if (!['email', 'adr', 'tel'].includes(property.field)) {
+        if (!FIELDS_WITH_PREF.includes(property.field)) {
             return property;
         }
 


### PR DESCRIPTION
For Vcard fields that admit more than one value, there is a PREF parameter that sets the preference of the different values. We were not saving this parameter in the Vcard, leading to the bugs described in #341 and #339.

Fixes #341. Fixes #339

As a sidenote: this bug went undetected till now because somehow the fields were being saved in the right order in the Vcard (without the PREF parameter though), and read back in the same order. That order in the read-back was however altered in Firefox.