### PR TITLE
Change key labels and add new notifications

### DIFF
--- a/src/app/components/ContactKeysTable.js
+++ b/src/app/components/ContactKeysTable.js
@@ -203,12 +203,12 @@ const ContactKeysTable = ({ model, setModel }) => {
                                 (isValid(expiration) ? format(expiration, 'PP', { locale: dateLocale }) : '-'),
                             !isNarrow && algo,
                             <React.Fragment key={fingerprint}>
-                                {isActive ? <Badge>{c('Key badge').t`Active`}</Badge> : null}
+                                {isActive ? <Badge>{c('Key badge').t`Primary`}</Badge> : null}
                                 {isVerificationOnly ? (
                                     <Badge type="warning">{c('Key badge').t`Verification only`}</Badge>
                                 ) : null}
-                                {isWKD ? <Badge>{c('Key badge').t`WKD`}</Badge> : null}
-                                {isTrusted ? <Badge>{c('Key badge').t`Trusted`}</Badge> : null}
+                                {isWKD ? <Badge type="origin">{c('Key badge').t`WKD`}</Badge> : null}
+                                {isTrusted ? <Badge type="success">{c('Key badge').t`Trusted`}</Badge> : null}
                                 {isRevoked ? <Badge type="error">{c('Key badge').t`Revoked`}</Badge> : null}
                                 {isExpired ? <Badge type="error">{c('Key badge').t`Expired`}</Badge> : null}
                             </React.Fragment>,

--- a/src/app/components/ContactKeysTable.js
+++ b/src/app/components/ContactKeysTable.js
@@ -35,7 +35,7 @@ const ContactKeysTable = ({ model, setModel }) => {
                     const isExpired = model.expiredFingerprints.has(fingerprint);
                     const isRevoked = model.revokedFingerprints.has(fingerprint);
                     const isVerificationOnly = model.verifyOnlyFingerprints.has(fingerprint);
-                    const isActive =
+                    const isPrimary =
                         !index &&
                         !isExpired &&
                         !isRevoked &&
@@ -43,7 +43,7 @@ const ContactKeysTable = ({ model, setModel }) => {
                         (totalApiKeys ? true : model.encrypt);
                     const isWKD = model.isPGPExternal && index < totalApiKeys;
                     const isUploaded = index >= totalApiKeys;
-                    const canBeActive =
+                    const canBePrimary =
                         !!index &&
                         !isExpired &&
                         !isRevoked &&
@@ -57,14 +57,14 @@ const ContactKeysTable = ({ model, setModel }) => {
                         algo,
                         creationTime,
                         expirationTime,
-                        isActive,
+                        isPrimary,
                         isWKD,
                         isExpired,
                         isRevoked,
                         isTrusted,
                         isVerificationOnly,
                         isUploaded,
-                        canBeActive,
+                        canBePrimary,
                         canBeTrusted,
                         canBeUntrusted
                     };
@@ -100,7 +100,7 @@ const ContactKeysTable = ({ model, setModel }) => {
                         algo,
                         creationTime,
                         expirationTime,
-                        isActive,
+                        isPrimary,
                         isWKD,
                         publicKey,
                         isExpired,
@@ -108,7 +108,7 @@ const ContactKeysTable = ({ model, setModel }) => {
                         isTrusted,
                         isVerificationOnly,
                         isUploaded,
-                        canBeActive,
+                        canBePrimary,
                         canBeTrusted,
                         canBeUntrusted
                     }) => {
@@ -128,7 +128,7 @@ const ContactKeysTable = ({ model, setModel }) => {
                                     downloadFile(blob, filename);
                                 }
                             },
-                            canBeActive && {
+                            canBePrimary && {
                                 text: c('Action').t`Use for sending`,
                                 onClick() {
                                     const apiIndex = model.keys.api.findIndex(
@@ -203,7 +203,7 @@ const ContactKeysTable = ({ model, setModel }) => {
                                 (isValid(expiration) ? format(expiration, 'PP', { locale: dateLocale }) : '-'),
                             !isNarrow && algo,
                             <React.Fragment key={fingerprint}>
-                                {isActive ? <Badge>{c('Key badge').t`Primary`}</Badge> : null}
+                                {isPrimary ? <Badge>{c('Key badge').t`Primary`}</Badge> : null}
                                 {isVerificationOnly ? (
                                     <Badge type="warning">{c('Key badge').t`Verification only`}</Badge>
                                 ) : null}

--- a/src/app/components/ContactPgpSettings.js
+++ b/src/app/components/ContactPgpSettings.js
@@ -42,6 +42,13 @@ const ContactPgpSettings = ({ model, setModel }) => {
 
         await Promise.all(
             files.map(async (publicKey) => {
+                if (!publicKey.isPublic()) {
+                    // do not allow to upload private keys
+                    return createNotification({
+                        type: 'error',
+                        text: c('Error').t`Invalid public key file`
+                    });
+                }
                 const fingerprint = publicKey.getFingerprint();
                 const { isExpired, isRevoked } = await getKeyEncryptStatus(publicKey);
                 isExpired && expiredFingerprints.add(fingerprint);
@@ -51,6 +58,7 @@ const ContactPgpSettings = ({ model, setModel }) => {
                     return pinned.push(publicKey);
                 }
                 const indexFound = pinned.findIndex((publicKey) => publicKey.getFingerprint() === fingerprint);
+                createNotification({ text: c('Info').t`Duplicate key updated`, type: 'warning' });
                 return pinned.splice(indexFound, 1, publicKey);
             })
         );

--- a/src/app/components/ContactPgpSettings.js
+++ b/src/app/components/ContactPgpSettings.js
@@ -48,7 +48,7 @@ const ContactPgpSettings = ({ model, setModel }) => {
                         type: 'error',
                         text: c('Error').t`Invalid public key file`
                     });
-                    return Promise.resolve();
+                    return;
                 }
                 const fingerprint = publicKey.getFingerprint();
                 const { isExpired, isRevoked } = await getKeyEncryptStatus(publicKey);

--- a/src/app/components/ContactPgpSettings.js
+++ b/src/app/components/ContactPgpSettings.js
@@ -44,10 +44,11 @@ const ContactPgpSettings = ({ model, setModel }) => {
             files.map(async (publicKey) => {
                 if (!publicKey.isPublic()) {
                     // do not allow to upload private keys
-                    return createNotification({
+                    createNotification({
                         type: 'error',
                         text: c('Error').t`Invalid public key file`
                     });
+                    return Promise.resolve();
                 }
                 const fingerprint = publicKey.getFingerprint();
                 const { isExpired, isRevoked } = await getKeyEncryptStatus(publicKey);
@@ -55,11 +56,13 @@ const ContactPgpSettings = ({ model, setModel }) => {
                 isRevoked && revokedFingerprints.add(fingerprint);
                 if (!trustedFingerprints.has(fingerprint)) {
                     trustedFingerprints.add(fingerprint);
-                    return pinned.push(publicKey);
+                    pinned.push(publicKey);
+                    return;
                 }
                 const indexFound = pinned.findIndex((publicKey) => publicKey.getFingerprint() === fingerprint);
                 createNotification({ text: c('Info').t`Duplicate key updated`, type: 'warning' });
-                return pinned.splice(indexFound, 1, publicKey);
+                pinned.splice(indexFound, 1, publicKey);
+                return;
             })
         );
 


### PR DESCRIPTION
There's a mismatch between the labels we use in the keys tables that appear in Mail/Settings/Keys and Contacts/Email-Settings/Advanced-Contact-Editor. In the former, we use ACTIVE for keys that are not expired or revoked, and PRIMARY to indicate the key that is currently being used to encrypt incoming emails. In the latter, we use ACTIVE to indicated the key that is currently being used for encrypting outgoing emails. This is probably gonna be confusing for the user.