### PR TITLE
Fix a few issues with images

### DIFF
--- a/src/app/components/ContactImageField.js
+++ b/src/app/components/ContactImageField.js
@@ -5,7 +5,13 @@ import { Button, img } from 'react-components';
 
 const ContactImageField = ({ value, onChange }) => {
     return (
-        <div>{value ? <img src={value} /> : <Button onClick={onChange}>{c('Action').t`Upload picture`}</Button>}</div>
+        <div>
+            {value ? (
+                <img src={value} referrerPolicy="no-referrer" />
+            ) : (
+                <Button onClick={onChange}>{c('Action').t`Upload picture`}</Button>
+            )}
+        </div>
     );
 };
 

--- a/src/app/components/ContactImageModal.js
+++ b/src/app/components/ContactImageModal.js
@@ -7,8 +7,11 @@ import { CONTACT_IMG_SIZE } from '../constants';
 
 const ContactImageModal = ({ url: initialUrl, onSubmit, onClose, ...rest }) => {
     const [url, setUrl] = useState(initialUrl);
-    const title = c('Title').t`Edit image`;
     const { createNotification } = useNotifications();
+
+    const title = c('Title').t`Edit image`;
+    const isBase64Str = url.startsWith('data:image');
+
     const handleChange = ({ target }) => setUrl(target.value);
 
     const handleSubmit = () => {
@@ -48,7 +51,7 @@ const ContactImageModal = ({ url: initialUrl, onSubmit, onClose, ...rest }) => {
                 <Field>
                     <Input
                         id="contactImageModal-input-url"
-                        value={url}
+                        value={isBase64Str ? '' : url}
                         onChange={handleChange}
                         placeholder={c('Placeholder').t`Image URL`}
                     />

--- a/src/app/components/ContactImageSummary.js
+++ b/src/app/components/ContactImageSummary.js
@@ -10,12 +10,12 @@ import { SHOW_IMAGES } from 'proton-shared/lib/constants';
 import { CONTACT_IMG_SIZE } from '../constants';
 
 const ContactImageSummary = ({ photo, name }) => {
-    const [showAnyways, setShowAnyways] = useState(!isURL(photo));
+    const [showAnyway, setShowAnyway] = useState(!isURL(photo));
     const [image, setImage] = useState({ src: photo });
     const [{ ShowImages }, loadingMailSettings] = useMailSettings();
     const [loadingResize, withLoadingResize] = useLoading(true);
     const loading = loadingMailSettings || loadingResize;
-    const showPhoto = ShowImages & SHOW_IMAGES.REMOTE || showAnyways;
+    const showPhoto = ShowImages & SHOW_IMAGES.REMOTE || showAnyway;
 
     useEffect(() => {
         if (!photo || !showPhoto) {
@@ -25,7 +25,8 @@ const ContactImageSummary = ({ photo, name }) => {
             const { src, width, height } = await toImage(photo);
 
             if (width <= CONTACT_IMG_SIZE && height <= CONTACT_IMG_SIZE) {
-                return setImage({ src, width, height, isSmall: true });
+                setImage({ src, width, height, isSmall: true });
+                return;
             }
             const resized = await resizeImage({
                 original: photo,
@@ -48,7 +49,7 @@ const ContactImageSummary = ({ photo, name }) => {
         );
     }
 
-    const handleClick = () => setShowAnyways(true);
+    const handleClick = () => setShowAnyway(true);
 
     if (showPhoto) {
         if (loading) {
@@ -62,6 +63,7 @@ const ContactImageSummary = ({ photo, name }) => {
         };
 
         if (!image.isSmall) {
+            // fit the image in the rounded container as background image
             return (
                 <div className="rounded50 ratio-container-square" style={style}>
                     <span className="inner-ratio-container" />
@@ -69,10 +71,12 @@ const ContactImageSummary = ({ photo, name }) => {
             );
         }
 
+        // For a small image, we have to create a smaller rounded container inside the bigger standard one,
+        // and fit the image as background inside it. As container width we must pick the smallest dimension
         return (
             <div className="rounded50 ratio-container-square mb0">
                 <span className="inner-ratio-container flex">
-                    <div className="mbauto mtauto center" style={{ width: `${image.width}px` }}>
+                    <div className="mbauto mtauto center" style={{ width: `${Math.min(image.width, image.height)}px` }}>
                         <div className="rounded50 ratio-container-square" style={style}>
                             <span className="inner-ratio-container" />
                         </div>

--- a/src/app/components/ContactImageSummary.js
+++ b/src/app/components/ContactImageSummary.js
@@ -36,6 +36,8 @@ const ContactImageSummary = ({ photo, name }) => {
             });
             setImage({ src: resized });
         };
+        // if resize fails (e.g. toImage will throw if the requested resource hasn't specified a CORS policy),
+        // fallback to the original src
         withLoadingResize(resize().catch(noop));
     }, [photo, showPhoto]);
 


### PR DESCRIPTION
* Fix #194.
* Small images with width > height were not being rendered properly as contact pictures.
* In the 'Edit image' modal we were displaying very long base64 strings in the URL field in the case of resized images. The browser freezes when clicking on those, so it's better not to show them, since anyway that field is meant for external URLs.
* Clarify possible errors that may happen when loading images from external websites (see https://github.com/ProtonMail/proton-shared/pull/109).

